### PR TITLE
fix(ci): extend all-algorithms test matrix timeout to 90 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
     needs: core-validation
     runs-on: ubuntu-latest
     # Full workspace `cargo test` + `cargo test --profile release-ci` for `std,all-algorithms`
-    # routinely approaches or exceeds 35 minutes as crates/tests grow; avoid false timeouts.
-    timeout-minutes: 60
+    # exceeds 60 minutes as the workspace grows; other matrix rows stay at 60m.
+    timeout-minutes: ${{ matrix.timeout_minutes || 60 }}
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +85,7 @@ jobs:
           - name: "all-algorithms"
             features: "std,all-algorithms"
             package: ""
+            timeout_minutes: 90
           - name: "ml-kem"
             features: "std,ml-kem,rand"
             package: ""


### PR DESCRIPTION
## Summary
- Give the \ll-algorithms\ test-matrix row a 90 minute job timeout instead of sharing the 60 minute default.
- Keep all other test-matrix rows at 60 minutes via \matrix.timeout_minutes || 60\.

## Context
During PR #34 CI, \Test Matrix (all-algorithms, std,all-algorithms)\ was cancelled twice at ~60 minutes while still compiling/running release-ci tests. Final Validation passed, but the row showed as failed/cancelled in GitHub checks.

## Test plan
- [ ] Confirm \Test Matrix (all-algorithms, std,all-algorithms)\ completes on this PR without cancellation.
- [ ] Confirm other test-matrix rows still use the 60 minute default.