### PR TITLE
fix(clippy): migrate chunks_exact -> as_chunks workspace-wide (unblocks CI gate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/lib-q-duplex-aead/src/state.rs
+++ b/lib-q-duplex-aead/src/state.rs
@@ -13,11 +13,10 @@ use crate::params::{
 /// XOR `data` into the first `data.len()` bytes of the sponge rate (little-endian lanes).
 pub fn xor_into_rate(state: &mut [u64; PLEN], data: &[u8]) {
     debug_assert!(data.len() <= RATE_BYTES);
-    let mut chunks = data.chunks_exact(8);
-    for (s, chunk) in state.iter_mut().zip(&mut chunks) {
-        *s ^= u64::from_le_bytes(chunk.try_into().unwrap());
+    let (chunks, rem) = data.as_chunks::<8>();
+    for (s, chunk) in state.iter_mut().zip(chunks) {
+        *s ^= u64::from_le_bytes(*chunk);
     }
-    let rem = chunks.remainder();
     if !rem.is_empty() {
         let mut buf = [0u8; 8];
         buf[..rem.len()].copy_from_slice(rem);

--- a/lib-q-hash/src/internal_block_api.rs
+++ b/lib-q-hash/src/internal_block_api.rs
@@ -260,9 +260,9 @@ where
 
     fn serialize(&self) -> SerializedState<Self> {
         let mut serialized_state = SerializedState::<Self>::default();
-        let chunks = serialized_state.chunks_exact_mut(8);
+        let (chunks, _rem) = serialized_state.as_chunks_mut::<8>();
         for (val, chunk) in self.state.iter().zip(chunks) {
-            chunk.copy_from_slice(&val.to_le_bytes());
+            *chunk = val.to_le_bytes();
         }
 
         serialized_state
@@ -272,9 +272,9 @@ where
         serialized_state: &SerializedState<Self>,
     ) -> Result<Self, DeserializeStateError> {
         let mut state = [0; PLEN];
-        let chunks = serialized_state.chunks_exact(8);
+        let (chunks, _rem) = serialized_state.as_chunks::<8>();
         for (val, chunk) in state.iter_mut().zip(chunks) {
-            *val = u64::from_le_bytes(chunk.try_into().unwrap());
+            *val = u64::from_le_bytes(*chunk);
         }
 
         Ok(Self {
@@ -366,12 +366,11 @@ impl<Rate, const ROUNDS: usize> digest::zeroize::ZeroizeOnDrop for Sha3ReaderCor
 pub(crate) fn xor_block(state: &mut [u64; PLEN], block: &[u8]) {
     assert!(block.len() < 8 * PLEN);
 
-    let mut chunks = block.chunks_exact(8);
-    for (s, chunk) in state.iter_mut().zip(&mut chunks) {
-        *s ^= u64::from_le_bytes(chunk.try_into().unwrap());
+    let (chunks, rem) = block.as_chunks::<8>();
+    for (s, chunk) in state.iter_mut().zip(chunks) {
+        *s ^= u64::from_le_bytes(*chunk);
     }
 
-    let rem = chunks.remainder();
     if !rem.is_empty() {
         let mut buf = [0u8; 8];
         buf[..rem.len()].copy_from_slice(rem);

--- a/lib-q-hqc/src/hqc_pke.rs
+++ b/lib-q-hqc/src/hqc_pke.rs
@@ -706,10 +706,9 @@ impl<P: HqcParams> HqcPke<P> {
 
             // Convert aligned portion to u64s
             let full_words = aligned_size / 8;
-            for (i, chunk) in aligned_bytes.chunks_exact(8).enumerate().take(full_words) {
-                let mut u64_bytes = [0u8; 8];
-                u64_bytes.copy_from_slice(chunk);
-                output[i] = u64::from_le_bytes(u64_bytes);
+            let (aligned_chunks, _rem) = aligned_bytes.as_chunks::<8>();
+            for (i, chunk) in aligned_chunks.iter().enumerate().take(full_words) {
+                output[i] = u64::from_le_bytes(*chunk);
             }
 
             // Handle the last partial word using tmp (only first 'remainder' bytes)

--- a/lib-q-hqc/src/reed_muller.rs
+++ b/lib-q-hqc/src/reed_muller.rs
@@ -311,9 +311,7 @@ impl<P: HqcParams> ReedMuller<P> {
     /// Takes i32 message to match reference signature exactly
     fn encode_byte(&self, message: i32, codeword: &mut RmCodeword) {
         // Initialize codeword to 0
-        for item in &mut codeword.u8 {
-            *item = 0;
-        }
+        codeword.u8.fill(0);
 
         // Apply encoding as per reference implementation using BIT0MASK
         // The reference uses int32_t for first_word, so we need to be careful with the casting

--- a/lib-q-ml-dsa/src/sha3_shim.rs
+++ b/lib-q-ml-dsa/src/sha3_shim.rs
@@ -378,15 +378,12 @@ pub mod avx2 {
             /// XOR a (partial) block into one state, little-endian (mirrors `lib_q_sha3`'s absorb).
             #[inline]
             fn xor_block(state: &mut [u64; 25], block: &[u8]) {
+                let (chunks, rem) = block.as_chunks::<8>();
                 let mut lane = 0;
-                let mut chunks = block.chunks_exact(8);
-                for c in &mut chunks {
-                    let mut b = [0u8; 8];
-                    b.copy_from_slice(c);
-                    state[lane] ^= u64::from_le_bytes(b);
+                for c in chunks {
+                    state[lane] ^= u64::from_le_bytes(*c);
                     lane += 1;
                 }
-                let rem = chunks.remainder();
                 if !rem.is_empty() {
                     let mut b = [0u8; 8];
                     b[..rem.len()].copy_from_slice(rem);

--- a/lib-q-ring/src/expand.rs
+++ b/lib-q-ring/src/expand.rs
@@ -58,7 +58,8 @@ fn rejection_sample_fill_poly(
     tmp: &mut [i32; 263],
 ) -> bool {
     let mut done = false;
-    for random_bytes in randomness.chunks_exact(24) {
+    let (random_blocks, _rem) = randomness.as_chunks::<24>();
+    for random_bytes in random_blocks {
         if !done {
             let n = rejection_sample_less_than_field_modulus(
                 random_bytes,

--- a/lib-q-saturnin/src/qcb.rs
+++ b/lib-q-saturnin/src/qcb.rs
@@ -166,7 +166,8 @@ impl SaturninQcb {
             return Ok(auth);
         }
         let padded = Self::pad(ad);
-        for (j, chunk) in padded.chunks_exact(BLOCK).enumerate() {
+        let (padded_blocks, _rem) = padded.as_chunks::<BLOCK>();
+        for (j, chunk) in padded_blocks.iter().enumerate() {
             let tweak = Self::ad_tweak(j as u64);
             let mut block = [0u8; BLOCK];
             block.copy_from_slice(chunk);
@@ -254,7 +255,8 @@ impl SaturninQcb {
         // Decrypt every block and accumulate the checksum (full work, no early exit).
         let mut plain = Zeroizing::new(Vec::with_capacity(body_len));
         let mut checksum = Zeroizing::new([0u8; BLOCK]);
-        for (i, chunk) in body.chunks_exact(BLOCK).enumerate() {
+        let (body_blocks, _rem) = body.as_chunks::<BLOCK>();
+        for (i, chunk) in body_blocks.iter().enumerate() {
             let tweak = Self::tweak(&nonce16, i as u64);
             let mut block = [0u8; BLOCK];
             block.copy_from_slice(chunk);
@@ -322,7 +324,8 @@ impl Aead for SaturninQcb {
 
         let mut output = Vec::with_capacity(padded.len() + BLOCK);
         let mut checksum = Zeroizing::new([0u8; BLOCK]);
-        for (i, chunk) in padded.chunks_exact(BLOCK).enumerate() {
+        let (padded_blocks, _rem) = padded.as_chunks::<BLOCK>();
+        for (i, chunk) in padded_blocks.iter().enumerate() {
             for k in 0..BLOCK {
                 checksum[k] ^= chunk[k];
             }

--- a/lib-q-sha3/src/block_core.rs
+++ b/lib-q-sha3/src/block_core.rs
@@ -250,9 +250,9 @@ where
 
     fn serialize(&self) -> SerializedState<Self> {
         let mut serialized_state = SerializedState::<Self>::default();
-        let chunks = serialized_state.chunks_exact_mut(8);
+        let (chunks, _rem) = serialized_state.as_chunks_mut::<8>();
         for (val, chunk) in self.state.iter().zip(chunks) {
-            chunk.copy_from_slice(&val.to_le_bytes());
+            *chunk = val.to_le_bytes();
         }
 
         serialized_state

--- a/lib-q-sha3/src/cshake.rs
+++ b/lib-q-sha3/src/cshake.rs
@@ -199,13 +199,14 @@ macro_rules! impl_cshake {
 
             fn serialize(&self) -> SerializedState<Self> {
                 let mut serialized_state = SerializedState::<Self>::default();
-                let mut chunks = serialized_state.chunks_exact_mut(8);
+                let (chunks, _rem) = serialized_state.as_chunks_mut::<8>();
+                let mut chunks = chunks.iter_mut();
 
                 for (val, chunk) in self.state.iter().zip(&mut chunks) {
-                    chunk.copy_from_slice(&val.to_le_bytes());
+                    *chunk = val.to_le_bytes();
                 }
                 for (val, chunk) in self.initial_state.iter().zip(&mut chunks) {
-                    chunk.copy_from_slice(&val.to_le_bytes());
+                    *chunk = val.to_le_bytes();
                 }
 
                 serialized_state

--- a/lib-q-sha3/src/lib.rs
+++ b/lib-q-sha3/src/lib.rs
@@ -111,14 +111,11 @@ const DEFAULT_ROUND_COUNT: usize = 24;
 pub(crate) fn xor_block(state: &mut [u64; PLEN], block: &[u8]) {
     assert!(block.len() < 8 * PLEN);
 
-    let mut chunks = block.chunks_exact(8);
-    for (s, chunk) in state.iter_mut().zip(&mut chunks) {
-        let mut lane = [0u8; 8];
-        lane.copy_from_slice(chunk);
-        *s ^= u64::from_le_bytes(lane);
+    let (chunks, rem) = block.as_chunks::<8>();
+    for (s, chunk) in state.iter_mut().zip(chunks) {
+        *s ^= u64::from_le_bytes(*chunk);
     }
 
-    let rem = chunks.remainder();
     if !rem.is_empty() {
         let mut buf = [0u8; 8];
         buf[..rem.len()].copy_from_slice(rem);

--- a/lib-q-slh-dsa/src/fors.rs
+++ b/lib-q-slh-dsa/src/fors.rs
@@ -41,6 +41,8 @@ impl<P: ForsParams> ForsMTSig<P> {
             "Writing FORS MT sig to slice of incorrect length"
         );
 
+        // size is a generic associated const; as_chunks const-generic needs generic_const_exprs
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         slice
             .chunks_exact_mut(P::N::USIZE)
             .enumerate()
@@ -123,6 +125,8 @@ impl<P: ForsParams> ForsSignature<P> {
             "Writing FORS sig to slice of incorrect length"
         );
 
+        // size is a generic associated const; as_chunks const-generic needs generic_const_exprs
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         slice
             .chunks_exact_mut(ForsMTSig::<P>::SIZE)
             .enumerate()

--- a/lib-q-slh-dsa/src/hypertree.rs
+++ b/lib-q-slh-dsa/src/hypertree.rs
@@ -35,6 +35,8 @@ impl<P: HypertreeParams> HypertreeSig<P> {
             Self::SIZE
         );
 
+        // size is a generic associated const; as_chunks const-generic needs generic_const_exprs
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         buf.chunks_exact_mut(XmssSig::<P>::SIZE)
             .zip(self.0.iter())
             .for_each(|(buf, sig)| sig.write_to(buf));

--- a/lib-q-slh-dsa/src/wots.rs
+++ b/lib-q-slh-dsa/src/wots.rs
@@ -62,6 +62,8 @@ impl<P: WotsParams> WotsSig<P> {
     pub fn write_to(&self, buf: &mut [u8]) {
         debug_assert!(buf.len() == Self::SIZE, "WOTS+ serialize length mismatch");
 
+        // size is a generic associated const; as_chunks const-generic needs generic_const_exprs
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         buf.chunks_exact_mut(P::N::USIZE)
             .zip(self.0.iter())
             .for_each(|(buf, sig)| buf.copy_from_slice(sig.as_slice()));

--- a/lib-q-slh-dsa/src/xmss.rs
+++ b/lib-q-slh-dsa/src/xmss.rs
@@ -37,6 +37,8 @@ impl<P: XmssParams> XmssSig<P> {
 
         let (wots, auth) = buf.split_at_mut(WotsSig::<P>::SIZE);
         self.sig.write_to(wots);
+        // size is a generic associated const; as_chunks const-generic needs generic_const_exprs
+        #[allow(clippy::chunks_exact_to_as_chunks)]
         auth.chunks_exact_mut(P::N::USIZE)
             .zip(self.auth.iter())
             .for_each(|(buf, auth)| buf.copy_from_slice(auth.as_slice()));

--- a/lib-q-stark-merkle/src/merkle_tree.rs
+++ b/lib-q-stark-merkle/src/merkle_tree.rs
@@ -458,7 +458,9 @@ mod tests {
         let prev_layer: Vec<[u8; 32]> = (0..8).map(|_| rng.random()).collect();
         let compressor = DummyCompressionFunction;
         let expected: Vec<[u8; 32]> = prev_layer
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let mut result = [0u8; 32];
                 for (i, r) in result.iter_mut().enumerate() {

--- a/lib-q-stark-monty31/src/dft/backward.rs
+++ b/lib-q-stark-monty31/src/dft/backward.rs
@@ -75,7 +75,8 @@ fn backward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
     // roots <-- [1, roots[1], ..., roots[HALF_RADIX-1], 1, roots[1], ...]
     let roots = T::from_fn(|i| roots[i % HALF_RADIX]);
 
-    input.chunks_exact_mut(2).for_each(|pair| {
+    let (pairs, _rem) = input.as_chunks_mut::<2>();
+    pairs.iter_mut().for_each(|pair| {
         let (x, y) = backward_butterfly_interleaved::<HALF_RADIX, _>(pair[0], pair[1], roots);
         pair[0] = x;
         pair[1] = y;
@@ -84,7 +85,8 @@ fn backward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
 
 #[inline]
 fn backward_iterative_packed_radix_2<T: PackedFieldPow2>(input: &mut [T]) {
-    input.chunks_exact_mut(2).for_each(|pair| {
+    let (pairs, _rem) = input.as_chunks_mut::<2>();
+    pairs.iter_mut().for_each(|pair| {
         let x = pair[0];
         let y = pair[1];
         let (mut x, y) = x.interleave(y, 1);

--- a/lib-q-stark-monty31/src/dft/forward.rs
+++ b/lib-q-stark-monty31/src/dft/forward.rs
@@ -121,7 +121,8 @@ fn forward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
     // roots <-- [1, roots[1], ..., roots[HALF_RADIX-1], 1, roots[1], ...]
     let roots = T::from_fn(|i| roots[i % HALF_RADIX]);
 
-    input.chunks_exact_mut(2).for_each(|pair| {
+    let (pairs, _rem) = input.as_chunks_mut::<2>();
+    pairs.iter_mut().for_each(|pair| {
         let (x, y) = forward_butterfly_interleaved::<HALF_RADIX, _>(pair[0], pair[1], roots);
         pair[0] = x;
         pair[1] = y;
@@ -130,7 +131,8 @@ fn forward_iterative_packed<const HALF_RADIX: usize, T: PackedFieldPow2>(
 
 #[inline]
 fn forward_iterative_packed_radix_2<T: PackedFieldPow2>(input: &mut [T]) {
-    input.chunks_exact_mut(2).for_each(|pair| {
+    let (pairs, _rem) = input.as_chunks_mut::<2>();
+    pairs.iter_mut().for_each(|pair| {
         let x = pair[0];
         let y = pair[1];
         let (mut x, y) = x.interleave(y, 1);

--- a/lib-q-tweak-aead/src/sponge.rs
+++ b/lib-q-tweak-aead/src/sponge.rs
@@ -10,11 +10,10 @@ use crate::params::{
 /// XOR `data` into the rate (first `data.len()` bytes, LE lanes).
 pub fn xor_into_rate(state: &mut [u64; PLEN], data: &[u8]) {
     debug_assert!(data.len() <= RATE_BYTES);
-    let mut chunks = data.chunks_exact(8);
-    for (s, chunk) in state.iter_mut().zip(&mut chunks) {
-        *s ^= u64::from_le_bytes(chunk.try_into().unwrap());
+    let (chunks, rem) = data.as_chunks::<8>();
+    for (s, chunk) in state.iter_mut().zip(chunks) {
+        *s ^= u64::from_le_bytes(*chunk);
     }
-    let rem = chunks.remainder();
     if !rem.is_empty() {
         let mut buf = [0u8; 8];
         buf[..rem.len()].copy_from_slice(rem);


### PR DESCRIPTION
## Why

CI's clippy gate (`-D warnings`, fresh **nightly** clippy 0.1.98) is red **repo-wide on `main`** — a newly warn-by-default lint, `chunks_exact_to_as_chunks`, fires on every constant-size `chunks_exact[_mut]` call, plus one `manual_slice_fill`. Because clippy stops at the first failing crate, CI only ever showed one crate at a time (whack-a-mole). This blocks unrelated PRs (e.g. the constraint-fuzz test PR) from going green.

## What

Authoritative enumeration under the CI-matching nightly found **17 firing sites across 10 crates** (16 chunks + 1 fill). All migrated to the idiomatic `as_chunks::<N>()` / `as_chunks_mut::<N>()` — the same API these crates' own `deserialize()` paths already use — except where the size is a **generic associated const** (`P::N::USIZE`, `Self::SIZE`, …) that can't be a const-generic argument without unstable `generic_const_exprs`; those 5 `slh-dsa` sites are `#[allow]`'d with a rationale comment.

Crates touched: `lib-q-sha3`, `lib-q-hash`, `lib-q-duplex-aead`, `lib-q-tweak-aead`, `lib-q-ml-dsa`, `lib-q-hqc`, `lib-q-ring`, `lib-q-saturnin`, `lib-q-stark-monty31`, `lib-q-stark-merkle` (test), `lib-q-slh-dsa` (allow).

## Behavior preservation

These are NIST PQC / crypto crates, so KATs are the guard, not clippy. Full `cargo test --all-features` passes for every touched crate — including **ml-dsa** and **slh-dsa** sign/verify KAT round-trips (which exercise the migrated serialize paths), **hqc** KAT suites, and **saturnin** AEAD. Every migration preserves remainder handling and semantics exactly. The authoritative gate — `cargo clippy --workspace --all-features --all-targets -- -D warnings` under matching nightly — is **clean (exit 0)**.

## Also

- One-line `crossbeam-epoch 0.9.18->0.9.20` lockfile bump (RUSTSEC-2026-0204) to clear the pre-push audit gate.