### PR TITLE
Code-scanning cleanup: workflow permissions + README version sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ env:
   # setup-node@v4 and other legacy JS actions; v5+ runs on Node 24 (GH Actions runner default Jun 2026).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  # Least-privilege default; jobs that need more elevate locally (e.g. coverage badge commit).
+  contents: read
+
 jobs:
   # Core validation pipeline - runs first and fastest
   core-validation:
@@ -1038,6 +1042,12 @@ jobs:
         run: |
           cargo doc --all-features --no-deps
           cargo doc --all-features --no-deps --document-private-items
+
+      # READMEs are static on crates.io, so version/MSRV strings can drift from the
+      # workspace manifest. This gate keeps the root Cargo.toml the single source of
+      # truth; on failure run `python scripts/sync-readme-versions.py --fix`.
+      - name: README version/MSRV sync
+        run: python3 scripts/sync-readme-versions.py --check
 
   # Specialized algorithm testing - parallel execution
   algorithm-tests:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,10 @@ env:
   RUSTFLAGS: "-D warnings"
   COVERAGE_THRESHOLD: "70"
 
+permissions:
+  # Least-privilege default; jobs that need more elevate locally (e.g. coverage badge commit).
+  contents: read
+
 jobs:
   coverage:
     name: Test Coverage

--- a/.github/workflows/security-critical-coverage.yml
+++ b/.github/workflows/security-critical-coverage.yml
@@ -12,6 +12,10 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
 
+permissions:
+  # Least-privilege default; jobs that need more elevate locally (e.g. coverage badge commit).
+  contents: read
+
 jobs:
   lib-q-sig-critical:
     name: lib-q-sig scoped coverage

--- a/.github/workflows/zkp-fuzz-scheduled.yml
+++ b/.github/workflows/zkp-fuzz-scheduled.yml
@@ -11,6 +11,10 @@ on:
 env:
   CARGO_INCREMENTAL: "0"
 
+permissions:
+  # Least-privilege default; jobs that need more elevate locally (e.g. coverage badge commit).
+  contents: read
+
 jobs:
   fuzz:
     name: cargo-fuzz (lib-q-zkp)

--- a/lib-q-cb-kem/README.md
+++ b/lib-q-cb-kem/README.md
@@ -41,14 +41,14 @@ Anyone, how wants to use Classic McEliece to negotiate a key between two parties
 Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-lib-q-cb-kem = { version = "0.0.5", path = "../lib-q-cb-kem" }  # from workspace root
+lib-q-cb-kem = { version = "0.0.9", path = "../lib-q-cb-kem" }  # from workspace root
 ```
 
 To use a specific Classic McEliece variant, you need to import it with the corresponding feature flag:
 
 ```toml
 [dependencies]
-lib-q-cb-kem = { version = "0.0.5", features = ["mceliece6960119"] }
+lib-q-cb-kem = { version = "0.0.9", features = ["mceliece6960119"] }
 ```
 
 Assuming this dependency, the simplest and most ergonomic way of using the library

--- a/lib-q-fn-dsa/README.md
+++ b/lib-q-fn-dsa/README.md
@@ -32,7 +32,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lib-q-fn-dsa = "0.0.5"
+lib-q-fn-dsa = "0.0.9"
 ```
 
 ### Node.js
@@ -176,7 +176,7 @@ This crate is fully integrated into the libQ ecosystem:
 
 ### Version Differences
 
-This implementation is based on the upstream `fn-dsa` reference implementation but uses version `0.0.5` of the internal crates (`fn-dsa-comm`, `fn-dsa-kgen`, `fn-dsa-sign`, `fn-dsa-vrfy`) rather than the upstream `0.3.0` version. This version difference was chosen during integration into the libQ workspace to maintain consistency with the libQ versioning scheme.
+This implementation is based on the upstream `fn-dsa` reference implementation but uses version `0.0.9` of the internal crates (`fn-dsa-comm`, `fn-dsa-kgen`, `fn-dsa-sign`, `fn-dsa-vrfy`) rather than the upstream `0.3.0` version. This version difference was chosen during integration into the libQ workspace to maintain consistency with the libQ versioning scheme.
 
 ### Security Improvements
 

--- a/lib-q-intrinsics/README.md
+++ b/lib-q-intrinsics/README.md
@@ -62,7 +62,7 @@ The library uses feature flags to control which intrinsics are compiled:
 
 ```toml
 [dependencies]
-lib-q-intrinsics = { version = "0.0.5", features = ["simd256"] }
+lib-q-intrinsics = { version = "0.0.9", features = ["simd256"] }
 ```
 
 Available features:

--- a/lib-q-keccak/README.md
+++ b/lib-q-keccak/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lib-q-keccak = "0.0.5"
+lib-q-keccak = "0.0.9"
 ```
 
 ### Basic Example
@@ -54,7 +54,7 @@ f1600(&mut state);
 
 ```toml
 [dependencies]
-lib-q-keccak = { version = "0.0.5", features = ["simd", "multithreading"] }
+lib-q-keccak = { version = "0.0.9", features = ["simd", "multithreading"] }
 ```
 
 ## Feature Flags
@@ -70,7 +70,7 @@ lib-q-keccak = { version = "0.0.5", features = ["simd", "multithreading"] }
 
 ## Minimum Supported Rust Version
 
-Rust **1.89** or higher.
+Rust **1.96** or higher.
 
 ## SemVer Policy
 
@@ -97,7 +97,7 @@ additional terms or conditions.
 [build-image]: https://github.com/Enkom-Tech/libQ/workflows/CI/badge.svg
 [build-link]: https://github.com/Enkom-Tech/libQ/actions
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.89+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.96+-blue.svg
 
 [//]: # (general links)
 

--- a/lib-q-kem/README.md
+++ b/lib-q-kem/README.md
@@ -21,7 +21,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lib-q-kem = { version = "0.0.5", features = ["ml-kem"] }
+lib-q-kem = { version = "0.0.9", features = ["ml-kem"] }
 ```
 
 Basic usage:
@@ -109,7 +109,7 @@ Example:
 
 ```toml
 [dependencies]
-lib-q-kem = { version = "0.0.5", features = ["ml-kem"] }
+lib-q-kem = { version = "0.0.9", features = ["ml-kem"] }
 ```
 
 ## Testing

--- a/lib-q-plonky/README.md
+++ b/lib-q-plonky/README.md
@@ -24,7 +24,7 @@ Add to `Cargo.toml`:
 # From another workspace member, use a path dependency:
 lib-q-plonky = { path = "../lib-q-plonky", features = ["full"] }
 # or crates.io once published:
-# lib-q-plonky = { version = "0.0.5", features = ["full"] }
+# lib-q-plonky = { version = "0.0.9", features = ["full"] }
 ```
 
 All components are built on the `lib-q-stark-*` primitives (SHAKE256-oriented pipeline).

--- a/lib-q-random/README.md
+++ b/lib-q-random/README.md
@@ -24,10 +24,10 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lib-q-random = "0.0.5"
+lib-q-random = "0.0.9"
 
 # For custom entropy sources in no_std/WASM environments
-lib-q-random = { version = "0.0.5", features = ["custom-entropy"] }
+lib-q-random = { version = "0.0.9", features = ["custom-entropy"] }
 ```
 
 ### Basic Usage

--- a/lib-q-saturnin/README.md
+++ b/lib-q-saturnin/README.md
@@ -14,7 +14,7 @@ Add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-lib-q-saturnin = "0.0.5"
+lib-q-saturnin = "0.0.9"
 ```
 
 ### AEAD

--- a/scripts/sync-readme-versions.py
+++ b/scripts/sync-readme-versions.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Keep README version/MSRV strings in sync with the workspace Cargo.toml.
+
+The workspace root `Cargo.toml` (`[workspace.package]`) is the single source of
+truth. crates.io renders READMEs as static markdown, so they can't read the
+manifest at render time; instead we regenerate/validate the handful of version-
+and MSRV-bearing strings from it.
+
+Rewrites, in every README.md (excluding vendored / reference / node_modules /
+target trees):
+
+  * lib-q dependency pins        lib-q-foo = "0.0.5"                 -> workspace version
+                                 lib-q-foo = { version = "0.0.5" }  -> workspace version
+  * Rust-version badge           rustc-1.85+                         -> rustc-<msrv>+
+  * MSRV prose                   Rust **1.85**                       -> Rust **<msrv>**
+                                 1.85 or higher                      -> <msrv> or higher
+                                 lines mentioning MSRV: bare 1.NN    -> <msrv>
+
+Usage:
+  python scripts/sync-readme-versions.py --check   # non-zero exit on drift (CI)
+  python scripts/sync-readme-versions.py --fix     # rewrite in place
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+EXCLUDE_PARTS = {"reference", "node_modules", "target", "vendor", "pkg-build"}
+
+
+def read_workspace_meta() -> tuple[str, str]:
+    """Return (version, msrv_minor) from [workspace.package] in the root Cargo.toml."""
+    text = (REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    block = re.search(r"\[workspace\.package\](.*?)(?:\n\[|\Z)", text, re.DOTALL)
+    if not block:
+        sys.exit("could not find [workspace.package] in Cargo.toml")
+    body = block.group(1)
+    version = re.search(r'^\s*version\s*=\s*"([^"]+)"', body, re.MULTILINE)
+    rustver = re.search(r'^\s*rust-version\s*=\s*"([^"]+)"', body, re.MULTILINE)
+    if not version or not rustver:
+        sys.exit("workspace.package must set both version and rust-version")
+    # MSRV is displayed as major.minor (1.96.0 -> 1.96) in badges/prose.
+    msrv_full = rustver.group(1)
+    msrv_minor = ".".join(msrv_full.split(".")[:2])
+    return version.group(1), msrv_minor
+
+
+def transform(text: str, version: str, msrv: str) -> str:
+    # lib-q dependency pins: capture the prefix up to the opening quote, swap the 0.0.x.
+    text = re.sub(
+        r'(lib-q[\w-]*\s*=\s*(?:\{[^}\n]*?version\s*=\s*)?")0\.0\.\d+(")',
+        lambda m: f"{m.group(1)}{version}{m.group(2)}",
+        text,
+    )
+    # Rust-version badge (shields.io): rustc-1.85 -> rustc-<msrv>
+    text = re.sub(r"rustc-1\.\d+(\.\d+)?", f"rustc-{msrv}", text)
+    # Prose: **1.85** in a "Rust **x**" phrase
+    text = re.sub(r"(Rust\s*\*\*)1\.\d+(\*\*)", lambda m: f"{m.group(1)}{msrv}{m.group(2)}", text)
+    # Prose: "1.85 or higher"
+    text = re.sub(r"1\.\d+(\.\d+)?( or higher)", lambda m: f"{msrv}{m.group(2)}", text)
+    # Any line that talks about MSRV: normalise a bare 1.NN token on it.
+    def fix_msrv_line(line: str) -> str:
+        if "MSRV" in line:
+            return re.sub(r"1\.\d+(\.\d+)?", msrv, line)
+        return line
+    text = "\n".join(fix_msrv_line(l) for l in text.split("\n"))
+    return text
+
+
+def iter_readmes() -> list[pathlib.Path]:
+    out = []
+    for p in REPO_ROOT.rglob("README.md"):
+        rel = p.relative_to(REPO_ROOT)
+        if EXCLUDE_PARTS & set(rel.parts):
+            continue
+        out.append(p)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="exit non-zero if any README is out of sync")
+    mode.add_argument("--fix", action="store_true", help="rewrite READMEs in place")
+    args = ap.parse_args()
+
+    version, msrv = read_workspace_meta()
+    drift: list[pathlib.Path] = []
+    for path in iter_readmes():
+        original = path.read_text(encoding="utf-8")
+        updated = transform(original, version, msrv)
+        if updated != original:
+            drift.append(path.relative_to(REPO_ROOT))
+            if args.fix:
+                path.write_text(updated, encoding="utf-8", newline="\n")
+
+    if not drift:
+        print(f"READMEs in sync (version {version}, MSRV {msrv}).")
+        return 0
+    if args.fix:
+        print(f"Synced {len(drift)} README(s) to version {version}, MSRV {msrv}:")
+        for d in drift:
+            print(f"  {d.as_posix()}")
+        return 0
+    print(f"{len(drift)} README(s) out of sync with version {version} / MSRV {msrv}:", file=sys.stderr)
+    for d in drift:
+        print(f"  {d.as_posix()}", file=sys.stderr)
+    print("Run: python scripts/sync-readme-versions.py --fix", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Resolves the actionable half of the open GitHub code-scanning alerts and adds durable tooling so README version/MSRV strings can't drift again.

## Changes

**1. Least-privilege workflow permissions (resolves 25 `actions/missing-workflow-permissions`)**
Added a top-level `permissions: contents: read` floor to the four workflows that lacked one: `ci.yml`, `coverage.yml`, `security-critical-coverage.yml`, `zkp-fuzz-scheduled.yml`. None of them have token-writing steps except the coverage badge-commit job, which keeps its own job-level `contents: write` (overrides the floor for that job only).

**2. README version/MSRV sync tooling + gate**
`scripts/sync-readme-versions.py` makes the root `Cargo.toml` (`[workspace.package]`) the single source of truth for README version pins and MSRV strings (crates.io READMEs are static, so they drift). `--check` (wired into the `documentation` CI job) fails on drift; `--fix` rewrites. Swept 8 crate READMEs from stale `0.0.2`/`0.0.5` → `0.0.9` and `1.89` → `1.96`, plus a prose fix in fn-dsa. Generated `pkg/` (wasm-pack) READMEs inherit on next build.

## Not included here
- The **58 false-positive** code-scanning alerts (hard-coded-crypto-value on standardized constants/KATs, weak-algo on the NIST KAT DRBG, cleartext-logging on test/estimator output) are being dismissed via the code-scanning API separately, not via code change.
- The 25 workflow-permissions alerts will auto-close once this merges and CodeQL re-scans.

https://claude.ai/code/session_01SibQKSaPENjwxughU8FJ23
