### PR TITLE
ci: trim redundant debug-lattice work from full-workspace test rows

### DIFF
--- a/.github/actions/rust-test/action.yml
+++ b/.github/actions/rust-test/action.yml
@@ -207,11 +207,20 @@ runs:
               cargo test -p $PACKAGE "${FEAT_ARGS[@]}" --verbose
             fi
           else
-            # Whole-workspace debug pass (std / all-algorithms shards). Exclude the heavy STARK
-            # crate lib-q-zk-encryption-proof: its debug proving is far too slow (same rationale as
-            # the per-package skip list above) and was tipping these already-tight shards over their
-            # timeout caps. It is fully covered by its own dedicated release-ci shard.
-            cargo test "${FEAT_ARGS[@]}" --workspace --exclude lib-q-zk-encryption-proof --verbose
+            # Whole-workspace debug pass (std / all-algorithms shards). Exclude the heavy lattice /
+            # STARK crates whose *debug* keygen/proof math is far too slow — the exact set the
+            # per-package path (above) already skips in debug and runs in release-ci only. Testing
+            # them here in debug re-does that slow work for zero extra signal (they are covered by
+            # their own dedicated release-ci rows AND by the whole-workspace release pass below),
+            # and it was the single biggest contributor to these shards blowing their timeout caps.
+            cargo test "${FEAT_ARGS[@]}" --workspace \
+              --exclude lib-q-zk-encryption-proof \
+              --exclude lib-q-blind-token \
+              --exclude lib-q-dkg \
+              --exclude lib-q-threshold-raccoon \
+              --exclude lib-q-threshold-kem-lattice \
+              --exclude lib-q-fn-dsa \
+              --verbose
           fi
         fi
         echo "Tests completed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,14 +130,18 @@ jobs:
           - name: "std"
             features: "std"
             package: ""
-            # TEMP (measurement probe): raised 60->150 to learn the true full-workspace runtime and
-            # surface any failures hidden behind the old cap. Revert/optimize once measured.
-            timeout_minutes: 150
+            # The whole-workspace debug pass no longer re-runs the slow lattice crates in debug
+            # (excluded in the rust-test action; they run release-ci in their own rows + the release
+            # pass here), so this row is well under the old 60m baseline. Kept at 90 for headroom
+            # until the first optimized run is measured, then trim toward 60.
+            timeout_minutes: 90
           - name: "all-algorithms"
             features: "std,all-algorithms"
             package: ""
-            # TEMP (measurement probe): raised 90->180 (CD pre-release-validation caps this at 150).
-            timeout_minutes: 180
+            # Same debug-lattice exclusion as the std row. Previously never finished at 180m; the
+            # exclusion removes that overrun. 120 is a conservative cap (CD pre-release-validation
+            # caps this at 150) pending the first measured optimized run.
+            timeout_minutes: 120
           - name: "ml-kem"
             features: "std,ml-kem,rand"
             package: ""


### PR DESCRIPTION
## Summary

Cuts the runtime of the two full-workspace `Test Matrix` rows (`std`, `all-algorithms`) by removing redundant **debug-mode** testing of the slow lattice crates. The `all-algorithms` row previously never finished within its 180-minute cap; this removes that overrun with **no coverage loss**.

## Root cause

Each of those rows runs `cargo test --workspace` **twice** — debug + `release-ci`. The debug pass re-ran full lattice keygen/proof math for `blind-token`, `dkg`, `threshold-raccoon`, `threshold-kem-lattice`, and `fn-dsa` — the exact set that every per-crate matrix row already skips in debug (debug lattice keygen is prohibitively slow) and runs in `release-ci` only. So the whole-workspace debug pass was redoing the slowest work in CI for zero extra signal.

## Change

- `.github/actions/rust-test/action.yml` — extend the `--exclude` list on the **whole-workspace debug pass only** to that same lattice set (the release pass is untouched and still exercises every crate).
- `.github/workflows/ci.yml` — lower the probe caps accordingly: `std` 150→90, `all-algorithms` 180→120. Conservative pending the first measured optimized run (then trim `std` toward its historical 60m).

## Why coverage is preserved

Every excluded crate is still tested:
1. in its own dedicated `Test Matrix` row (`release-ci`), and
2. in the whole-workspace **release** pass of these same rows.

Only the duplicate, far-slower **debug** execution is dropped.

## Note

Carries the same one-off `style(zkp)` nightly-rustfmt reformat that #61/#62 needed (pre-existing drift on `main`). The durable fix — pinning rustfmt in `rust-toolchain.toml` so the floating nightly stops reformatting on every branch — is worth its own small infra PR.
