### PR TITLE
ci(coverage): stop the Test Coverage job timing out at 45:00

### DIFF
--- a/.github/actions/rust-test/action.yml
+++ b/.github/actions/rust-test/action.yml
@@ -127,10 +127,15 @@ runs:
           echo "skip=false" >> $GITHUB_OUTPUT
         fi
     
+    # Prebuilt binary, not `cargo install cargo-tarpaulin`: building tarpaulin from source
+    # burned ~3 min of every coverage job's wall clock (measured on runs 30093529070 /
+    # 30105432016) before a single test had run. That is pure overhead against the job's
+    # timeout budget on the heaviest coverage target (lib-q-zkp).
     - name: Install cargo-tarpaulin (if coverage enabled)
       if: inputs.run-coverage == 'true' && steps.coverage-skip.outputs.skip != 'true'
-      shell: bash
-      run: cargo install cargo-tarpaulin
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-tarpaulin
     
     - name: Run tests
       shell: bash

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,8 +80,9 @@ jobs:
           key: ${{ runner.os }}-cargo-coverage-${{ matrix.rust }}-${{ steps.toolchain-fp.outputs.hash }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
           
       - name: Install tarpaulin
-        run: |
-          cargo install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
           
       # First run coverage for individual critical crates
       - name: Run coverage for core cryptographic crates

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,12 +80,14 @@ jobs:
     name: Test Coverage
     needs: core-validation
     runs-on: ubuntu-latest
-    # 45 min: the heaviest affected-crate case is lib-q-zkp, whose instrumented lib-tests
+    # 60 min: the heaviest affected-crate case is lib-q-zkp, whose instrumented lib-tests
     # alone run ~10 min under `tarpaulin --engine llvm` (full STARK prove/verify round-trips),
-    # and with tarpaulin install + doctests + the other zkp test binaries the single-crate
-    # pass lands at ~29-30 min — chronically grazing the old 30-min cap. Bumped so zkp-touching
-    # PRs don't red-out on a wall-clock timeout that isn't a real test/coverage-threshold failure.
-    timeout-minutes: 45
+    # and with doctests + the other zkp test binaries the single-crate pass lands at ~29-30 min.
+    # The 45-min cap was still too tight in practice: it passed on PR #61 but timed out on
+    # #62 and #63 at exactly 45:00 — a wall-clock cancel, not a test or coverage-threshold
+    # failure. Runner-speed variance alone spans that margin, so the cap needs real headroom.
+    # (The ~3 min tarpaulin source build is separately removed in .github/actions/rust-test.)
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
       

--- a/.github/workflows/security-critical-coverage.yml
+++ b/.github/workflows/security-critical-coverage.yml
@@ -40,7 +40,9 @@ jobs:
           key: ${{ runner.os }}-sec-cov-sig-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
 
       - name: Generate scoped Cobertura
         run: |
@@ -100,7 +102,9 @@ jobs:
           key: ${{ runner.os }}-sec-cov-tkeml-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
 
       - name: Generate scoped Cobertura
         run: |


### PR DESCRIPTION
Stacked on #64 (base is `chore/pin-nightly-toolchain`; GitHub retargets to `main` once #64 merges). Needs that base because `main` is not fmt-clean under current nightly, which is what #64 fixes.

## Why

The PR **Test Coverage** job has been cancelled at *exactly* 45:00 on #62, #63 and #64:

| PR | job | duration |
|----|-----|----------|
| #62 | Test Coverage | 12:38:20 → 13:23:35 (45:15) |
| #63 | Test Coverage | 15:36:49 → 16:22:04 (45:15) |
| #64 | Test Coverage | cancelled, same cap |

That is a **wall-clock timeout**, not a test failure and not a coverage-threshold miss. The same job *passed* on #61 with the same resolved crate (`lib-q-zkp`), so the margin sits inside ordinary runner-speed variance — it reds out a PR at random.

## What

- **Prebuilt tarpaulin.** `cargo install cargo-tarpaulin` compiled it from source on every run — ~3 min of pure setup before a single test executed (measured: run 30093529070 12:38:47→12:41:28, run 30105432016 15:37:16→15:40:01). Swapped to `taiki-e/install-action@v2` at all four call sites: the shared `rust-test` composite action, `coverage.yml`, and both jobs in `security-critical-coverage.yml`.
- **Cap 45 → 60 min**, so the heaviest affected-crate case has real headroom instead of grazing the limit.

## Note on why `lib-q-zkp` kept getting selected

The affected-package resolver picks the first changed crate. Every open branch carried the identical `style(zkp)` reformat commit, so each one resolved to `lib-q-zkp` — the single most expensive coverage target — regardless of what it actually changed (#62 is blind-token, #63 is CI-only). #64 removes that commit's reason to exist, so unrelated PRs stop paying for zkp coverage. This PR fixes the remaining case: PRs that genuinely *do* touch `lib-q-zkp`.

## Verification

All four YAML files parse. No Rust touched.


---

*Supersedes #65, which GitHub auto-closed when its stacked base branch
(`chore/pin-nightly-toolchain`, PR #64) was deleted on merge. Same branch, same
single commit, rebased onto the post-#64 `main` — the toolchain commit dropped as
already-upstream, so the diff here is exactly the four CI files.*
