### PR TITLE
fix(fn-dsa): portable keygen never terminates for n>=8 — wrong n=2 unroll in poly_sub_scaled

### DIFF
--- a/.github/actions/rust-test/action.yml
+++ b/.github/actions/rust-test/action.yml
@@ -464,9 +464,12 @@ runs:
           fi
         fi
         
-        if [[ "$PACKAGE" == "lib-q-fn-dsa" ]]; then
-          TARPAULIN_CMD="$TARPAULIN_CMD -- keypair_generation test_basic_fn_dsa_functionality"
-        elif [[ "$PACKAGE" == "lib-q-kem" ]]; then
+        # lib-q-fn-dsa used to filter down to `keypair_generation
+        # test_basic_fn_dsa_functionality` here. Coverage is measured against
+        # lib-q-fn-dsa/src/lib.rs, so running 2 of the crate's ~34 tests scored it at
+        # 129/199 = 64.82% and tripped the default 70% floor -- a number about the filter,
+        # not about the crate. Run the whole suite so the figure means something.
+        if [[ "$PACKAGE" == "lib-q-kem" ]]; then
           TARPAULIN_CMD="$TARPAULIN_CMD -- --test-threads=1"
         fi
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1286,6 +1286,80 @@ jobs:
           cargo test -p lib-q-sca-test --release --features hqc-hardened --lib hqc_hardened_tvla_and_dudect_smoke
           cargo test -p lib-q-sca-test --release --features hqc-hardened --test self_cert_report -- --exact self_cert_smoke
 
+  # Portable (no_avx2) FN-DSA path — closes a CI blind spot: FN-DSA's field/keccak/poly/sampler
+  # code is dispatched AVX2-vs-portable at *runtime* (`has_avx2()`), and every existing x86_64
+  # runner in this workflow has AVX2, so no job anywhere ever compiled or executed the portable
+  # branch — a defect confined to it (e.g. a portable-keygen livelock) builds clean and passes
+  # every other row silently. Force the fallback with `--features no_avx2`, which lib-q-fn-dsa
+  # forwards to -comm/-kgen/-sign/-vrfy (see lib-q-fn-dsa/Cargo.toml:62 and
+  # lib-q-fn-dsa/fn-dsa/Cargo.toml:30), so the portable code actually runs on the runners we
+  # have, without waiting on real ARM/wasm hardware (tracked separately as a follow-up).
+  #
+  # No other workspace crate has a comparable *force*-portable feature: lib-q-hqc / lib-q-saturnin
+  # / lib-q-duplex-aead / lib-q-tweak-aead expose `simd-avx2` as opt-in-only (off by default, so
+  # the portable path they ship is already what every ordinary test row exercises); lib-q-keccak /
+  # lib-q-rocca-s / lib-q-platform / lib-q-random / lib-q-slh-dsa runtime-detect AVX2 with no
+  # compile-time override at all. Only the fn-dsa family has the "silently prefers SIMD, and you
+  # can't turn it off" shape this job exists to cover.
+  #
+  # lib-q-fn-dsa-kgen's own KAT/self-test (`test_keygen_ref_full_kat`, `test_keygen_self`) are
+  # `#[ignore]`d upstream for being slow, not because of this job, so they correctly don't run
+  # here either — same as every other job today. Separately (OBSERVED locally, timeout-bounded):
+  # the facade crate's own `self_test` (package `lib-q-fn-dsa-alg`, i.e. `lib-q-fn-dsa/fn-dsa/`)
+  # and the outer `lib-q-fn-dsa` crate's own tests all call live `keygen()` at n=512/1024 through
+  # the public API, which hits an open, input-dependent portable-keygen livelock on this branch
+  # (fix tracked on a separate branch) — so those two packages are compiled here (`--no-run`) but
+  # not executed yet; switch their step to a full `cargo test` once that fix lands. lib-q-fn-dsa
+  # -comm / -sign / -vrfy don't hit that call path today (vrfy's own KAT tests do call keygen, but
+  # with a fixed seed that happens not to trigger it) and run for real below.
+  fn-dsa-no-avx2:
+    name: FN-DSA Portable Path (no_avx2)
+    needs: core-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      # Debug builds of dependencies (e.g. num-bigint pulled in by fn-dsa-kgen) are slow; this
+      # speeds up dep compilation without changing the crates under test.
+      CARGO_PROFILE_DEV_PACKAGE_ALL_OPT_LEVEL: "2"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rust-src
+
+      - name: Cache dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-fndsa-no-avx2-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-fndsa-no-avx2-
+
+      - name: Portable-path tests (comm / sign / kgen / vrfy)
+        run: |
+          cargo test -p lib-q-fn-dsa-comm --features no_avx2
+          cargo test -p lib-q-fn-dsa-sign --features no_avx2
+          # kgen's own two tests are #[ignore]d upstream (slow full keygen KAT / self-test) and
+          # correctly don't run here; this still compiles+links the portable keygen code under
+          # no_avx2 (previously never even compiled in CI) and runs its non-keygen unit tests
+          # (gauss/fxp/mp31/zint31/vect/poly — the math primitives portable keygen is built from).
+          cargo test -p lib-q-fn-dsa-kgen --features no_avx2
+          cargo test -p lib-q-fn-dsa-vrfy --features no_avx2
+
+      - name: Portable-path build check (fn-dsa-alg facade / outer lib-q-fn-dsa)
+        run: |
+          # Every test in these two packages generates a real key pair at n=512/1024 through the
+          # public API / self_test, which hits the open portable-keygen livelock on this branch —
+          # compile only for now (still catches a no_avx2 build break, which no job caught before).
+          cargo test -p lib-q-fn-dsa-alg --features no_avx2 --no-run
+          cargo test -p lib-q-fn-dsa --features no_avx2 --no-run
+
   # SIMD debug verification for HQC
   simd-debug-tests:
     name: SIMD Debug Verification
@@ -1534,7 +1608,7 @@ jobs:
   # Final validation - runs after all other jobs
   final-validation:
     name: Final Validation
-    needs: [publish-readiness, test-matrix, wasm-validation, wasm-workspace-gate, wasm-bindgen-smoke, romulus-no-std-wasm, zkp-recursive, cross-platform, bench-shards-validate, performance-benches, documentation, algorithm-tests, simd-debug-tests, ml-dsa-compliance, ml-kem-tests, constant-time, integration-tests]
+    needs: [publish-readiness, test-matrix, wasm-validation, wasm-workspace-gate, wasm-bindgen-smoke, romulus-no-std-wasm, zkp-recursive, cross-platform, bench-shards-validate, performance-benches, documentation, algorithm-tests, fn-dsa-no-avx2, simd-debug-tests, ml-dsa-compliance, ml-kem-tests, constant-time, integration-tests]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1302,16 +1302,14 @@ jobs:
   # compile-time override at all. Only the fn-dsa family has the "silently prefers SIMD, and you
   # can't turn it off" shape this job exists to cover.
   #
-  # lib-q-fn-dsa-kgen's own KAT/self-test (`test_keygen_ref_full_kat`, `test_keygen_self`) are
-  # `#[ignore]`d upstream for being slow, not because of this job, so they correctly don't run
-  # here either — same as every other job today. Separately (OBSERVED locally, timeout-bounded):
-  # the facade crate's own `self_test` (package `lib-q-fn-dsa-alg`, i.e. `lib-q-fn-dsa/fn-dsa/`)
-  # and the outer `lib-q-fn-dsa` crate's own tests all call live `keygen()` at n=512/1024 through
-  # the public API, which hits an open, input-dependent portable-keygen livelock on this branch
-  # (fix tracked on a separate branch) — so those two packages are compiled here (`--no-run`) but
-  # not executed yet; switch their step to a full `cargo test` once that fix lands. lib-q-fn-dsa
-  # -comm / -sign / -vrfy don't hit that call path today (vrfy's own KAT tests do call keygen, but
-  # with a fixed seed that happens not to trigger it) and run for real below.
+  # All six FN-DSA packages are executed here, not merely compiled. That is only possible as of
+  # the portable-keygen fix in this same branch (the n=2 unrolled arm of `poly_sub_scaled`):
+  # before it, every test in `lib-q-fn-dsa-alg` and the outer `lib-q-fn-dsa` livelocked under
+  # no_avx2, because they all generate a real key pair at n=512/1024 through the public API.
+  # `lib-q-fn-dsa-kgen`'s `test_keygen_ref_full_kat` and `test_keygen_self` were `#[ignore]`d as
+  # "slow" for that same reason — circularly, since the bug is what made them slow — and are
+  # un-ignored in this branch. They exercise portable keygen most directly and now run in well
+  # under a second, so this job runs them for real too.
   fn-dsa-no-avx2:
     name: FN-DSA Portable Path (no_avx2)
     needs: core-validation
@@ -1341,24 +1339,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-fndsa-no-avx2-
 
-      - name: Portable-path tests (comm / sign / kgen / vrfy)
+      - name: Portable-path tests (all FN-DSA packages)
         run: |
           cargo test -p lib-q-fn-dsa-comm --features no_avx2
-          cargo test -p lib-q-fn-dsa-sign --features no_avx2
-          # kgen's own two tests are #[ignore]d upstream (slow full keygen KAT / self-test) and
-          # correctly don't run here; this still compiles+links the portable keygen code under
-          # no_avx2 (previously never even compiled in CI) and runs its non-keygen unit tests
-          # (gauss/fxp/mp31/zint31/vect/poly — the math primitives portable keygen is built from).
+          # kgen is the crate the livelock lived in. Its two keygen tests (un-ignored in this
+          # branch) cover logn 2..=10 and assert the portable keys are byte-identical to the
+          # AVX2 ones, so a portable-only regression fails here rather than silently shipping.
           cargo test -p lib-q-fn-dsa-kgen --features no_avx2
+          cargo test -p lib-q-fn-dsa-sign --features no_avx2
           cargo test -p lib-q-fn-dsa-vrfy --features no_avx2
-
-      - name: Portable-path build check (fn-dsa-alg facade / outer lib-q-fn-dsa)
-        run: |
-          # Every test in these two packages generates a real key pair at n=512/1024 through the
-          # public API / self_test, which hits the open portable-keygen livelock on this branch —
-          # compile only for now (still catches a no_avx2 build break, which no job caught before).
-          cargo test -p lib-q-fn-dsa-alg --features no_avx2 --no-run
-          cargo test -p lib-q-fn-dsa --features no_avx2 --no-run
+          # The facade and the outer crate reach portable keygen through the public API
+          # (`self_test` sweeps logn 2..8; the outer tests generate keys at n=512/1024).
+          cargo test -p lib-q-fn-dsa-alg --features no_avx2
+          cargo test -p lib-q-fn-dsa --features no_avx2
 
   # SIMD debug verification for HQC
   simd-debug-tests:

--- a/lib-q-fn-dsa/fn-dsa-kgen/src/lib.rs
+++ b/lib-q-fn-dsa/fn-dsa-kgen/src/lib.rs
@@ -1208,21 +1208,24 @@ mod tests {
         }
     }
 
-    /// Full SHA256 keygen KATs (degrees 256 / 512 / 1024). Too slow for routine `cargo test`
-    /// (NTRU solve); run before release or when touching keygen, e.g.
-    /// `cargo test -p lib-q-fn-dsa-kgen test_keygen_ref_full_kat -- --ignored --release --test-threads=1`
+    /// Full SHA256 keygen KATs (degrees 256 / 512 / 1024). Previously `#[ignore]`d as "too slow
+    /// for routine `cargo test`" -- that was an artifact of the portable `poly_sub_scaled` bug
+    /// fixed in commit e101182 (n=2 unrolled arm), which made NTRU keygen livelock (never
+    /// terminate) on any non-AVX2 build; x86 CI never noticed because it always took the AVX2
+    /// path. Post-fix this runs in well under a second in every profile (dev and release, with
+    /// and without `no_avx2`); see `poly::tests::poly_sub_scaled_arms_match_general` for the
+    /// direct regression guard on that bug.
     #[test]
-    #[ignore = "slow full keygen KAT; run with --ignored --release"]
     fn test_keygen_ref_full_kat() {
         inner_keygen_ref(8, &KAT_KG256);
         inner_keygen_ref(9, &KAT_KG512);
         inner_keygen_ref(10, &KAT_KG1024);
     }
 
-    /// NTRU identity check (all supported `logn`). Too slow for routine `cargo test` in debug;
-    /// run with `--ignored --release` (see also `test_keygen_ref_full_kat`).
+    /// NTRU identity check (all supported `logn`). Previously `#[ignore]`d for the same reason as
+    /// `test_keygen_ref_full_kat` above (portable keygen livelock, now fixed); runs in well under
+    /// a second post-fix.
     #[test]
-    #[ignore = "slow NTRU keygen self-test; run with --ignored --release"]
     fn test_keygen_self() {
         for logn in 2..11 {
             let n = 1usize << logn;

--- a/lib-q-fn-dsa/fn-dsa-kgen/src/poly.rs
+++ b/lib-q-fn-dsa/fn-dsa-kgen/src/poly.rs
@@ -337,10 +337,13 @@ pub(crate) fn poly_sub_scaled(
             }
             1 => {
                 // n = 2
+                // F[0] -= (k0*f0 - k1*f1)*2^sc
+                // F[1] -= (k0*f1 + k1*f0)*2^sc
                 let kf0 = k[0].wrapping_neg() as i32;
                 let kf1 = k[1].wrapping_neg() as i32;
                 zint_add_scaled_mul_small(&mut F[0..], Flen, &f[0..], flen, 2, kf0, sch, scl);
-                zint_add_scaled_mul_small(&mut F[1..], Flen, &f[1..], flen, 2, kf1, sch, scl);
+                zint_add_scaled_mul_small(&mut F[1..], Flen, &f[1..], flen, 2, kf0, sch, scl);
+                zint_add_scaled_mul_small(&mut F[1..], Flen, &f[0..], flen, 2, kf1, sch, scl);
                 zint_add_scaled_mul_small(
                     &mut F[0..],
                     Flen,

--- a/lib-q-fn-dsa/fn-dsa-kgen/src/poly.rs
+++ b/lib-q-fn-dsa/fn-dsa-kgen/src/poly.rs
@@ -305,28 +305,6 @@ pub(crate) fn poly_sub_scaled(
     }
     let flen = core::cmp::min(flen, Flen - (sch as usize));
 
-    let mut run_general = |n: usize| {
-        for i in 0..n {
-            let kf = k[i].wrapping_neg() as i32;
-            for j in i..n {
-                zint_add_scaled_mul_small(&mut F[j..], Flen, &f[(j - i)..], flen, n, kf, sch, scl);
-            }
-            let kf = kf.wrapping_neg();
-            for j in 0..i {
-                zint_add_scaled_mul_small(
-                    &mut F[j..],
-                    Flen,
-                    &f[((j + n) - i)..],
-                    flen,
-                    n,
-                    kf,
-                    sch,
-                    scl,
-                );
-            }
-        }
-    };
-
     // Optimize for small degrees (logn <= 3) with unrolled loops
     if logn <= 3 {
         match logn {
@@ -415,10 +393,50 @@ pub(crate) fn poly_sub_scaled(
                     }
                 }
             }
-            _ => run_general(1usize << logn),
+            _ => poly_sub_scaled_general(1usize << logn, F, Flen, f, flen, k, sch, scl),
         }
     } else {
-        run_general(1usize << logn);
+        poly_sub_scaled_general(1usize << logn, F, Flen, f, flen, k, sch, scl);
+    }
+}
+
+// General O(n^2) negacyclic-convolution loop behind poly_sub_scaled(), for
+// n = 2^logn coefficients. This is exactly upstream fn-dsa's (Thomas
+// Pornin, fn-dsa v0.3.0) single un-specialized loop, used here directly
+// for logn > 3, and kept as a standalone fn (rather than inlined) so it
+// can also serve as the equivalence oracle for the logn <= 3 unrolled
+// arms above: their whole purpose is to be bit-identical to this loop,
+// just faster. See the `poly_sub_scaled_arms_match_general` test below,
+// and the fix in commit e101182 (the n=2 arm broke exactly this contract
+// for coefficient 1).
+fn poly_sub_scaled_general(
+    n: usize,
+    F: &mut [u32],
+    Flen: usize,
+    f: &[u32],
+    flen: usize,
+    k: &[u32],
+    sch: u32,
+    scl: u32,
+) {
+    for i in 0..n {
+        let kf = k[i].wrapping_neg() as i32;
+        for j in i..n {
+            zint_add_scaled_mul_small(&mut F[j..], Flen, &f[(j - i)..], flen, n, kf, sch, scl);
+        }
+        let kf = kf.wrapping_neg();
+        for j in 0..i {
+            zint_add_scaled_mul_small(
+                &mut F[j..],
+                Flen,
+                &f[((j + n) - i)..],
+                flen,
+                n,
+                kf,
+                sch,
+                scl,
+            );
+        }
     }
 }
 
@@ -760,6 +778,140 @@ mod tests {
         for logn in 1..11 {
             for prime in PRIMES.iter().take(5) {
                 inner_NTT(logn, prime.g, prime.ig, prime.p, prime.p0i, prime.R2);
+            }
+        }
+    }
+
+    // Deterministic splitmix64 step. NOT re-seeded per run -- this is a
+    // fixed-seed PRNG so a failing case reproduces exactly on every
+    // machine/run, not just "sometimes locally".
+    fn sm64_next(state: &mut u64) -> u64 {
+        *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = *state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    // A pseudo-random big-integer limb: any 31-bit pattern is a valid word
+    // in the base-2^31 signed representation used throughout this module
+    // (the sign of the whole multi-word value lives in bit 30 of the top
+    // word, which this naturally randomizes too).
+    fn rand_word(state: &mut u64) -> u32 {
+        (sm64_next(state) as u32) & 0x7FFF_FFFF
+    }
+
+    // A signed i32 coefficient for `k`, encoded the way poly_sub_scaled's
+    // `k: &[u32]` parameter expects (raw bit pattern of the i32). The
+    // first few draws per test case are forced to adversarial edge values
+    // (zero, +-1, extremes) rather than left to chance, since those are
+    // exactly the values most likely to expose a sign/overflow mistake in
+    // a hand-unrolled arm; later draws are pseudo-random fill.
+    fn rand_k(state: &mut u64, draw: usize) -> u32 {
+        const EDGES: [i32; 8] = [
+            0,
+            1,
+            -1,
+            i32::MAX,
+            i32::MIN,
+            i32::MIN + 1,
+            i32::MAX - 1,
+            -12345,
+        ];
+        if draw < EDGES.len() {
+            EDGES[draw] as u32
+        } else {
+            sm64_next(state) as u32
+        }
+    }
+
+    // Regression test for the poly_sub_scaled() small-degree (logn <= 3)
+    // unrolled arms added on top of upstream fn-dsa. Upstream has a single
+    // general O(n^2) loop for all degrees (poly_sub_scaled_general() here,
+    // extracted unchanged from that loop); the port's whole justification
+    // for special-casing logn <= 3 is that the unrolled arms are bit-for-
+    // bit equivalent to that general loop, just faster. This test checks
+    // exactly that contract, directly, for all four arms (logn = 0..=3),
+    // not just logn = 1 (n = 2), which is the arm that was actually wrong:
+    // it computed F[1] -= k1*f1 instead of F[1] -= (k0*f1 + k1*f0), i.e.
+    // it used the wrong half of the negacyclic product's cross term. That
+    // bug made Babai reduction diverge for any keygen reaching an n=2
+    // intermediate level (logn_top >= 3), so solve_NTRU never succeeded
+    // and keygen_from_seed's rejection loop livelocked forever on the
+    // portable path (fixed in commit e101182).
+    //
+    // Coverage: several (Flen, flen, sc) shapes per logn, chosen to hit
+    // flen == Flen, flen < Flen, sc == 0, and sc large enough to make sch
+    // (the whole-word part of the shift) nonzero -- the n=2 arm's bug was
+    // in the cross-term routing, not the shift math, but sch != 0 also
+    // exercises the "not enough source words -> sign-extend" path inside
+    // zint_add_scaled_mul_small for good measure. Per shape, k is drawn
+    // per-coefficient from rand_k() above, so early coefficients hit the
+    // zero/negative/extreme edge values and the rest are pseudo-random
+    // fill; F and f contents are pseudo-random 31-bit words (their actual
+    // magnitude doesn't matter for this test -- only that both code paths
+    // are fed the identical bytes and must produce the identical result).
+    #[test]
+    fn poly_sub_scaled_arms_match_general() {
+        const MAXN: usize = 8; // n for logn = 3
+        const MAXLEN: usize = 6; // largest Flen/flen exercised below
+
+        let shapes: [(usize, usize, u32); 7] = [
+            (1, 1, 0),
+            (2, 2, 0),
+            (2, 1, 0),
+            (3, 3, 5),
+            (4, 2, 31), // sch = 1, scl = 0
+            (5, 3, 47), // sch = 1, scl = 16
+            (6, 4, 93), // sch = 3, scl = 0
+        ];
+
+        let mut state: u64 = 0x1234_5678_9ABC_DEF0;
+        let mut case_idx = 0usize;
+        for logn in 0u32..=3 {
+            let n = 1usize << logn;
+            for &(Flen, flen, sc) in shapes.iter() {
+                assert!(Flen <= MAXLEN && flen <= MAXLEN);
+
+                let mut f = [0u32; MAXN * MAXLEN];
+                let mut k = [0u32; MAXN];
+                let mut F0 = [0u32; MAXN * MAXLEN];
+
+                for w in F0.iter_mut().take(n * Flen) {
+                    *w = rand_word(&mut state);
+                }
+                for w in f.iter_mut().take(n * flen) {
+                    *w = rand_word(&mut state);
+                }
+                for (i, kw) in k.iter_mut().take(n).enumerate() {
+                    *kw = rand_k(&mut state, case_idx + i);
+                }
+
+                let mut F_arm = F0;
+                let mut F_gen = F0;
+
+                poly_sub_scaled(logn, &mut F_arm, Flen, &f, flen, &k, sc);
+
+                // Mirror poly_sub_scaled's own sch/Flen/flen clipping
+                // exactly (via the same divrem31()) so the reference call
+                // sees precisely the inputs the arm under test saw.
+                let (sch, scl) = divrem31(sc);
+                if (sch as usize) < Flen {
+                    let flen_c = core::cmp::min(flen, Flen - (sch as usize));
+                    poly_sub_scaled_general(n, &mut F_gen, Flen, &f, flen_c, &k, sch, scl);
+                }
+
+                assert!(
+                    F_arm[..n * Flen] == F_gen[..n * Flen],
+                    "mismatch: logn={} Flen={} flen={} sc={} case={}",
+                    logn,
+                    Flen,
+                    flen,
+                    sc,
+                    case_idx
+                );
+
+                case_idx += 1;
             }
         }
     }


### PR DESCRIPTION
FN-DSA key generation never terminates on the portable (non-AVX2) code path, for every degree `n >= 8`. It has been broken since the crate was first imported in `1a33a2d` (2026-05-17) — `git log -1` on each of `fn-dsa-kgen/src/{fxp,mp31,poly,vect,zint31,ntru,gauss}.rs` returns that commit and nothing since.

On x86_64 the portable path is normally dead code, which is why this went unnoticed. On **aarch64, armv7 and wasm32 it is the only path** — the dispatcher compiles its AVX2 branch solely for `target_arch = "x86"` / `"x86_64"`. FN-DSA is opt-in, but it is part of `all-algorithms`, and `lib-q-sig` exposes it through a public by-name factory, so a consumer enabling it on those targets hangs the calling thread indefinitely.

## Root cause

`fn-dsa-kgen/src/poly.rs`, `poly_sub_scaled`, the `1 =>` (logn=1, n=2) arm.

Upstream (Thomas Pornin's `fn-dsa` v0.3.0) has a single general loop plus a literal `// TODO: optimize cases with logn <= 3`. This port took up that TODO and hand-wrote an unrolled block. `poly_sub_scaled` computes `F -= (k*f mod X^n+1) * 2^sc`; at n=2 the negacyclic product is

```
(k*f)[0] = k0*f0 - k1*f1
(k*f)[1] = k0*f1 + k1*f0
```

The arm applied `k1` to `f[1]` for coefficient 1 — subtracting `k1*f1` instead of `k0*f1 + k1*f0`. Coefficient 0 was correct. The `0`/`2`/`3` arms are the general loop with a literal constant substituted for `n`, so they were right by construction; only the genuinely hand-unrolled arm was wrong.

**Why it livelocks for exactly logn 3..=10.** `poly_sub_scaled` is the Babai-reduction subtraction used by `solve_NTRU_intermediate` at depth >= 2 for small levels (level logn >= 4 uses `poly_sub_scaled_ntt`; depth 1 uses `poly_sub_kfg_scaled_depth1`). Any keygen with logn >= 3 recurses to a level with n=2 and hits the broken arm. The reduction then diverges, the resulting (F,G) are destroyed by FGlen word-truncation, the `f*G - g*F == q` check correctly rejects, `solve_NTRU` returns false, and the rejection-sampling loop in `keygen_from_seed` retries forever. logn=2 has depth 1 only, never calls `poly_sub_scaled`, and completes — which is precisely the observed boundary.

## What is in this PR

1. **The fix** — 3 lines: replace the one wrong call with the two the general loop performs.
2. **A regression guard for the actual contract.** The optimisation's correctness contract is "the `logn <= 3` arms are bit-identical to the general loop." `poly_sub_scaled_arms_match_general` asserts exactly that, for **all four arms**, over varied `(Flen, flen, sc)` shapes (including `flen < Flen` and `sc` large enough to make `sch != 0`) and `k` coefficients spanning zero, negative and near-`i32` extremes, with a fixed-seed splitmix64 so any failure reproduces exactly. The general loop is lifted from a closure into `poly_sub_scaled_general` so the test can call it as the oracle.
3. **Un-ignored `test_keygen_self` and `test_keygen_ref_full_kat`.** Their `#[ignore] = "slow"` was circular — the livelock is what made them slow. Measured post-fix: 0.21s–0.92s across {dev, release} x {default, no_avx2}.
4. **A CI job that forces the portable path** (`fn-dsa-no-avx2`), running all six FN-DSA packages with `--features no_avx2` on the existing x86_64 PR runners, wired into `final-validation`.

## Verification

Bug reintroduced by hand, then both guards checked:

| with the bug restored | result |
| --- | --- |
| `poly_sub_scaled_arms_match_general` | **FAILED** in 0.00s — `mismatch: logn=1 Flen=1 flen=1 sc=0 case=7` |
| `test_keygen_self` | **hung**, killed at a 60s cap (exit 143) |

Fix restored, `--features no_avx2`, all six packages executed:

```
lib-q-fn-dsa-comm    5 passed; 0 failed
lib-q-fn-dsa-kgen    9 passed; 0 failed
lib-q-fn-dsa-sign    8 passed; 0 failed
lib-q-fn-dsa-vrfy    2 passed; 0 failed
lib-q-fn-dsa-alg     2 passed; 0 failed   (self_test sweeps logn 2..8)
lib-q-fn-dsa        34 passed; 0 failed   (lib + integration + security)
```

`test_keygen_self` covers logn 2..=10 x 2 seeds, asserts the `f*G - g*F = q` identity, and asserts the portable keys are **byte-identical to the AVX2 ones** — the strongest available correctness check. Reference KATs (logn 8/9/10) pass. Default (AVX2) path unchanged: 12 passed. `cargo fmt --check` and `cargo clippy --all-targets` clean on the changed crate.

## Why CI never caught it

- `grep -rl "no_avx2" .github/workflows/` -> **0 files**. No row ever forced the portable dispatch.
- `--ignored` / `--include-ignored` -> **0 files**. The only two tests calling portable keygen directly were the `#[ignore]`d ones.
- `qemu` / `cross-rs` -> **0 files**. aarch64/armv7 rows are `cargo build` only, and that job is skipped entirely on pull requests.

And the trap: `fn-dsa/src/lib.rs` `self_test` loops `for logn in 2..8` over `KeyPairGeneratorWeak` — squarely inside the broken range — and **does** run in CI. On x86_64 `has_avx2()` is true, so it took the AVX2 branch every iteration and never touched the portable code it appears to test. CI looked covered.

## Scope — what this does NOT claim

- **Sign and verify are unaffected.** Checked, not assumed: on a freshly generated non-KAT key at logn 9 and 10, portable and AVX2 `sign()` produce byte-identical signatures from the same seed, and all four {AVX2, portable}-sign x {AVX2, portable}-verify combinations validate. A function-by-function diff of `fn-dsa-sign/{poly,sampler}.rs`, `fn-dsa-vrfy/lib.rs` and `fn-dsa-comm/{mq,shake,codec}.rs` against upstream v0.3.0 found only renames and reflow.
- **This is availability/correctness, not a break of the cryptography.** No evidence of key recovery, forgery, or weak-key generation — the failure mode is that keygen never returns.
- **Not executed on real aarch64/armv7/wasm32.** The non-x86 claim is inference from the shared code path plus an x86_64 `no_avx2` proxy. A QEMU/`cross` execution row is the right follow-up and is deliberately not in this PR.
- **`flr_emu.rs` remains uncovered.** `fn-dsa-sign` selects its float backend by `target_arch` independently of AVX2; wasm32/armv7 get the software-emulated one, which no test anywhere executes and which an x86_64 `no_avx2` run does not reach. Tracked separately.
