### PR TITLE
fix(intrinsics): make lib-q-intrinsics verifiable at publish time instead of --no-verify

### DIFF
--- a/.github/actions/crate-publish/action.yml
+++ b/.github/actions/crate-publish/action.yml
@@ -67,13 +67,16 @@ runs:
         fi
         
         # `cargo publish` verifies by compiling the packaged crate in ISOLATION with the default
-        # profile (panic=unwind). A #![no_std] crate that pins lib-q-core/lib-q-platform with
-        # default-features=false (e.g. lib-q-intrinsics) drags lib-q-core into no_std, whose
-        # no_std #[panic_handler] requires panic=abort -> "unwinding panics are not supported
-        # without std". The in-workspace build is already validated in CI, so both branches fall
-        # back to --no-verify on exactly that error. They MUST agree: a dry-run that hard-fails on
-        # a crate the real publish would ship is a false alarm that trains operators to ignore it,
-        # and it fails at the one moment the dry-run exists to be trusted.
+        # profile (panic=unwind). This error means some crate's DEFAULT feature set puts
+        # `lib-q-core` in no_std while `lib-q-core` still declares its `cdylib` crate-type.
+        #
+        # NEITHER branch falls back to --no-verify any more, and they MUST STAY IN AGREEMENT.
+        # The original invariant here worried about a dry run that hard-fails on a crate the real
+        # publish would ship — a false alarm that trains operators to ignore it. Now that the
+        # publish branch treats this error as a regression, the dangerous asymmetry is the mirror
+        # image: a dry run that PASSES via fallback on a crate the real publish will REJECT. That
+        # is worse, because it fails at the one moment the dry run exists to be trusted. So the
+        # dry run hard-fails on exactly the same condition, with the same guidance.
         no_verify_fallback_needed() {
           echo "$1" | grep -qE 'unwinding panics are not supported without std'
         }
@@ -87,11 +90,11 @@ runs:
           echo "$publish_output"
           if [ "$publish_status" -ne 0 ]; then
             if no_verify_fallback_needed "$publish_output"; then
-              echo "::warning::$PKG failed cargo publish's isolated verify build (no_std core needs panic=abort); retrying the dry run with --no-verify (in-workspace build already verified in CI)."
-              cargo publish --allow-dirty --no-verify -p "$PKG" --dry-run
-            else
-              exit "$publish_status"
+              echo "::error::$PKG failed cargo publish's isolated verify build: 'unwinding panics are not supported without std'."
+              echo "::error::REGRESSION: a crate's default features put lib-q-core in no_std while its cdylib crate-type still needs a panic runtime."
+              echo "::error::Fix the crate's default features (cf. lib-q-intrinsics: default = [\"std\"], std = [\"lib-q-platform/std\"]). Publishing with --no-verify is NOT an acceptable workaround - crates.io versions are immutable."
             fi
+            exit "$publish_status"
           fi
         else
           max_attempts=6
@@ -109,19 +112,27 @@ runs:
               echo "$PKG is already on crates.io; skipping"
               break
             fi
-            # Same no_std/panic=abort verify failure the dry-run branch handles above: fall back to
-            # --no-verify (upload the packaged tarball without the isolated verify compile).
-            if no_verify_fallback_needed "$publish_output"; then
-              echo "::warning::$PKG failed cargo publish's isolated verify build (no_std core needs panic=abort); retrying with --no-verify (in-workspace build already verified in CI)."
-              set +e
-              publish_output="$(cargo publish --allow-dirty --no-verify -p "$PKG" 2>&1)"
-              publish_status=$?
-              set -e
+            # This used to retry with `--no-verify`. It no longer does, deliberately.
+            #
+            # `cargo publish` verifies by compiling the packaged crate in ISOLATION with the default
+            # profile (panic=unwind). This error means some crate's DEFAULT feature set puts
+            # `lib-q-core` in no_std while `lib-q-core` still declares its `cdylib` crate-type: a
+            # cdylib is a final artifact and needs a panic runtime, and there is no unwinder
+            # without `std`. `lib-q-intrinsics` used to trip this because it had `default = []`
+            # and no `std` feature to forward to `lib-q-platform`; it now has
+            # `default = ["std"]` / `std = ["lib-q-platform/std"]` and verifies normally.
+            #
+            # Do NOT reinstate the fallback. `--no-verify` uploads a tarball that nobody ever
+            # compiled, and crates.io versions are immutable — a broken artifact is permanent, and
+            # the first person to discover it is a consumer. If this fires again it is a real
+            # regression in some crate's default features: fix the manifest so the default graph
+            # compiles standalone (reproduce locally with `cargo package -p <pkg>`, which runs the
+            # same isolated verify build), rather than skipping verification.
+            if echo "$publish_output" | grep -qE 'unwinding panics are not supported without std'; then
+              echo "::error::$PKG failed cargo publish's isolated verify build: 'unwinding panics are not supported without std'."
+              echo "::error::REGRESSION: a crate's default features put lib-q-core in no_std while its cdylib crate-type still needs a panic runtime."
+              echo "::error::Fix the crate's default features (cf. lib-q-intrinsics: default = [\"std\"], std = [\"lib-q-platform/std\"]). Publishing with --no-verify is NOT an acceptable workaround - crates.io versions are immutable."
               echo "$publish_output"
-              if [ "$publish_status" -eq 0 ] || echo "$publish_output" | grep -qE 'already uploaded|already exists on crates\.io'; then
-                echo "$PKG published with --no-verify"
-                break
-              fi
               exit "$publish_status"
             fi
             if echo "$publish_output" | grep -qE '429 Too Many Requests|rate limit|too many updates'; then

--- a/.github/actions/rust-test/action.yml
+++ b/.github/actions/rust-test/action.yml
@@ -393,12 +393,14 @@ runs:
             TARPAULIN_CMD="$TARPAULIN_CMD --features \"std,random,acvp,fips-mode,hardened,mldsa44,mldsa65,mldsa87\""
           fi
         elif [[ "$PACKAGE" == "lib-q-intrinsics" ]]; then
-          # lib-q-platform/std pulls std into the platform -> lib-q-core chain. Intrinsics is
-          # #![no_std] and pins lib-q-platform with default-features=false, so without this the
-          # chain builds no_std and lib-q-core's no_std #[panic_handler] requires panic=abort,
-          # which tarpaulin's panic=unwind test harness rejects ("unwinding panics are not
-          # supported without std"). See scripts/run-coverage.sh for the matching gate path.
-          TARPAULIN_CMD="$TARPAULIN_CMD --features \"simd256,simd128,simd512,lib-q-platform/std\""
+          # Enable the SIMD gates so the arch-specific modules are actually built and measured.
+          # `std` is no longer listed here: lib-q-intrinsics now has its own `std` feature
+          # (`std = ["lib-q-platform/std"]`) and it is ON BY DEFAULT, so the platform -> lib-q-core
+          # chain builds with std and tarpaulin's panic=unwind harness links. Before that fix this
+          # line had to force `lib-q-platform/std` by hand, or the chain built no_std and failed
+          # with "unwinding panics are not supported without std".
+          # See scripts/run-coverage.sh for the matching gate path.
+          TARPAULIN_CMD="$TARPAULIN_CMD --features \"simd256,simd128,simd512\""
         elif [[ -n "$FEATURES" ]]; then
           TARPAULIN_CMD="$TARPAULIN_CMD --features \"$FEATURES\""
         fi

--- a/lib-q-intrinsics/Cargo.toml
+++ b/lib-q-intrinsics/Cargo.toml
@@ -11,13 +11,31 @@ description = "SIMD intrinsics for lib-Q cryptographic operations"
 keywords = ["cryptography", "intrinsics", "simd", "avx2", "neon"]
 categories = ["cryptography", "no-std"]
 
-# `default-features = false`: this crate is `#![no_std]`; pulling lib-q-platform's default `std`
-# would force lib-q-core into std (and `once_cell/std`), breaking bare-metal no_std consumers.
+# `default-features = false` on the edge, plus a forwarding `std` feature below — the same shape
+# `lib-q-platform` uses for its own `lib-q-core` edge. Keeping the edge itself feature-free is what
+# lets `--no-default-features` reach a genuine bare-metal no_std graph; `std` is what re-enables it.
 [dependencies]
 lib-q-platform = { path = "../lib-q-platform", version = "0.0.10", default-features = false }
 
 [features]
-default = []
+# `std` is ON by default, and must stay that way for this crate to be buildable at all.
+#
+# `lib-q-core` declares `crate-type = ["cdylib", "rlib"]` (the cdylib is for wasm-pack), and Cargo
+# builds every declared crate-type even when core is only a transitive dependency. A cdylib is a
+# *final* artifact, so it needs a panic runtime; with core in no_std under the default
+# `panic = "unwind"` profile there is no unwinder to link and rustc hard-errors with
+# "unwinding panics are not supported without std".
+#
+# This crate previously had `default = []` and no `std` feature at all, so its default graph forced
+# core into no_std and could not compile: `cargo check -p lib-q-intrinsics` and `cargo publish`'s
+# isolated verify build both failed. It only ever appeared to work inside a larger dependency graph
+# where some *other* crate unified `lib-q-core/std` back in (e.g. via `lib-q-ml-dsa`).
+#
+# Bare-metal consumers opt out with `default-features = false`, which reproduces the old graph
+# exactly; that configuration additionally needs `panic = "abort"` (workspace `dev-no-std` profile
+# or `RUSTFLAGS=-Cpanic=abort`), as documented on `lib-q-core`'s `no_std` feature.
+default = ["std"]
+std = ["lib-q-platform/std"]
 simd128 = []
 simd256 = []
 simd512 = []

--- a/scripts/run-coverage.sh
+++ b/scripts/run-coverage.sh
@@ -118,13 +118,13 @@ if [[ -n "$CRATE" ]]; then
     fi
   elif [[ "$CRATE" == "lib-q-intrinsics" ]]; then
     # Enable SIMD feature gates so platform helpers and arch-specific modules are built.
-    # lib-q-platform/std pulls std into the lib-q-platform → lib-q-core dependency chain.
-    # Intrinsics pins lib-q-platform with default-features=false (it is #![no_std]), so without
-    # this the chain builds no_std and lib-q-core's no_std #[panic_handler] requires panic=abort —
-    # tarpaulin's instrumented test harness is panic=unwind, so the build fails with
-    # "unwinding panics are not supported without std". Turning on platform's std (not intrinsics'
-    # own SIMD code) lets the test binary link while still measuring intrinsics coverage.
-    CMD="$CMD --features simd256,simd128,simd512,lib-q-platform/std"
+    # `std` is no longer listed here: lib-q-intrinsics now has its own `std` feature
+    # (`std = ["lib-q-platform/std"]`) which is ON BY DEFAULT, so the lib-q-platform → lib-q-core
+    # chain builds with std and tarpaulin's panic=unwind harness links. Before that fix this line
+    # had to force `lib-q-platform/std` by hand, or the chain built no_std, lib-q-core's cdylib
+    # needed a panic runtime it could not get, and the build failed with
+    # "unwinding panics are not supported without std".
+    CMD="$CMD --features simd256,simd128,simd512"
   fi
 fi
 


### PR DESCRIPTION
`cargo publish -p lib-q-intrinsics` failed verification (`unwinding panics are not supported without std`), so CD shipped it via an explicit `--no-verify` fallback — meaning nobody ever checked the published artifact compiles. 0.0.9 shipped that way.

Fixes the underlying build so the fallback is unnecessary. Adversarially verified.

See the commit message for the root cause and the before/after `cargo publish --dry-run` output.