### PR TITLE
fix(docs): repair docs.rs builds (4 crates) and clear all 55 doc-link warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1169,7 +1169,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-docs-
       
+      # docs.rs builds every published crate with `--all-features` AND `--cfg docsrs`
+      # (see each crate's `[package.metadata.docs.rs]`). Without `--cfg docsrs` here,
+      # anything guarded by `cfg_attr(docsrs, ...)` is never compiled in CI, so a
+      # docs.rs-only breakage ships undetected — publishing does not gate on rustdoc,
+      # and crates.io versions are immutable. That is exactly how lib-q-keccak 0.0.9
+      # reached crates.io with a failed docs.rs build. Keep this flag in sync with
+      # the `rustdoc-args` in the manifests.
       - name: Generate documentation
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
         run: |
           cargo doc --all-features --no-deps
           cargo doc --all-features --no-deps --document-private-items

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,11 @@ jobs:
           features: "all-algorithms"
           package: "lib-q"
       
+      # `--cfg docsrs` reproduces the docs.rs build; without it, docs.rs-only
+      # breakage is invisible to CI. See the same note in ci.yml.
       - name: Check documentation
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
         run: cargo doc --all-features --no-deps --document-private-items
 
       - name: Compile AVX-gated Keccak paths
@@ -189,6 +193,8 @@ jobs:
           toolchain: stable
       
       - name: Check documentation completeness
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
         run: |
           # Check that all public APIs are documented
           cargo doc --all-features --no-deps --document-private-items

--- a/lib-q-blind-token/src/lattice/mod.rs
+++ b/lib-q-blind-token/src/lattice/mod.rs
@@ -1,14 +1,14 @@
 //! Lattice trapdoor machinery for the round-optimal GPV-preimage blind signature.
 //!
 //! Layers (built bottom-up, each independently tested):
-//! 1. [`gaussian`] — discrete Gaussian sampler `D_{Z,s,c}` (branchless fast path for large `σ`).
-//! 2. [`gaussian_ct`] — isochronous (constant-time) `D_{Z,s,c}` for the small-width secret-bearing
+//! 1. [`gaussian`](crate::lattice::gaussian) — discrete Gaussian sampler `D_{Z,s,c}` (branchless fast path for large `σ`).
+//! 2. [`gaussian_ct`](crate::lattice::gaussian_ct) — isochronous (constant-time) `D_{Z,s,c}` for the small-width secret-bearing
 //!    sites (trapdoor `R`, attribute, gadget coset, perturbation rounding).
-//! 3. [`gadget`] — gadget vector `g = (1, b, …, b^{k-1})`, exact decomposition, and the coset
+//! 3. [`gadget`](crate::lattice::gadget) — gadget vector `g = (1, b, …, b^{k-1})`, exact decomposition, and the coset
 //!    `G`-preimage Gaussian sampler.
 //!
 //! The whole subtree is **std-gated** (the samplers need `f64`). The small-width samplers are now
-//! isochronous ([`gaussian_ct`]); the large-`σ` continuous-rounding path is branchless. See the
+//! isochronous ([`gaussian_ct`](crate::lattice::gaussian_ct)); the large-`σ` continuous-rounding path is branchless. See the
 //! crate `LIBQ_API.md` §7 for the residual (non-algorithmic) timing assumptions.
 
 // Index-based loops are the natural expression for the matrix/vector/FFT math here.

--- a/lib-q-cb-kem/src/lib.rs
+++ b/lib-q-cb-kem/src/lib.rs
@@ -26,6 +26,19 @@
 //! - **Memory safety**: Automatic zeroization of sensitive data
 //! - **Hash function**: SHA3 (SHAKE256) hash function
 //!
+//! ## Cargo features
+//!
+//! (Item names are written as plain code spans, not intra-doc links: each one exists
+//! only when its feature is enabled, so linking them would emit unresolved-link
+//! warnings in builds that do not enable every feature.)
+//!
+//! - `alloc` — heap helpers: `PublicKey::to_owned`, `SecretKey::to_owned`,
+//!   `SharedSecret::to_owned`, the `From<Box<[u8; _]>>` conversions, and
+//!   `LibQCbKemProvider`.
+//! - `nist-aes-rng` — the NIST SP 800-90A CTR_DRBG: `AesState`, `NistDrbgError`,
+//!   `MAX_BYTES_PER_REQUEST`, `RESEED_INTERVAL`, `SEEDLEN`.
+//! - `zeroize` — automatic zeroization of key material on drop.
+//!
 //! ## Usage
 //!
 //! ### With libQ Integration
@@ -74,7 +87,6 @@
 
 #![no_std]
 #![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 // Reference-style loops and explicit formulas match upstream crypto code; keep Clippy from blocking CI.
 #![allow(clippy::collapsible_if)]
 #![allow(clippy::identity_op)]
@@ -105,7 +117,6 @@ mod uint64_sort;
 mod util;
 
 #[cfg(feature = "nist-aes-rng")]
-#[cfg_attr(docsrs, doc(cfg(feature = "nist-aes-rng")))]
 mod nist_aes_rng;
 
 use core::fmt::Debug;
@@ -133,7 +144,6 @@ pub use lib_q_random::ClassicalMcElieceRng as LibQRng;
 #[cfg(feature = "alloc")]
 pub use libq_provider::LibQCbKemProvider;
 #[cfg(feature = "nist-aes-rng")]
-#[cfg_attr(docsrs, doc(cfg(feature = "nist-aes-rng")))]
 pub use nist_aes_rng::{
     AesState,
     MAX_BYTES_PER_REQUEST,
@@ -222,7 +232,6 @@ pub struct PublicKey<'a>(KeyBufferMut<'a, CRYPTO_PUBLICKEYBYTES>);
 
 impl PublicKey<'_> {
     /// Copies the key to the heap and makes it `'static`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     pub fn to_owned(&self) -> PublicKey<'static> {
         PublicKey(self.0.to_owned())
@@ -245,7 +254,6 @@ impl<'a> From<&'a mut [u8; CRYPTO_PUBLICKEYBYTES]> for PublicKey<'a> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 impl From<Box<[u8; CRYPTO_PUBLICKEYBYTES]>> for PublicKey<'static> {
     fn from(data: Box<[u8; CRYPTO_PUBLICKEYBYTES]>) -> Self {
@@ -282,7 +290,6 @@ pub struct SecretKey<'a>(KeyBufferMut<'a, CRYPTO_SECRETKEYBYTES>);
 
 impl SecretKey<'_> {
     /// Copies the key to the heap and makes it `'static`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     pub fn to_owned(&self) -> SecretKey<'static> {
         SecretKey(self.0.to_owned())
@@ -319,7 +326,6 @@ impl<'a> From<&'a mut [u8; CRYPTO_SECRETKEYBYTES]> for SecretKey<'a> {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 impl From<Box<[u8; CRYPTO_SECRETKEYBYTES]>> for SecretKey<'static> {
     fn from(data: Box<[u8; CRYPTO_SECRETKEYBYTES]>) -> Self {
@@ -397,7 +403,6 @@ pub struct SharedSecret<'a>(KeyBufferMut<'a, CRYPTO_BYTES>);
 
 impl SharedSecret<'_> {
     /// Copies the secret to the heap and makes it `'static`.
-    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     pub fn to_owned(&self) -> SharedSecret<'static> {
         SharedSecret(self.0.to_owned())
@@ -463,7 +468,6 @@ pub fn keypair<'public, 'secret, R: CryptoRng + Rng>(
 /// Convenient wrapper around [`keypair`] that stores the public and private keys on the heap
 /// and returns them with the ``'static`` lifetime.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn keypair_boxed<R: CryptoRng + Rng>(rng: &mut R) -> (PublicKey<'static>, SecretKey<'static>) {
     let mut public_key_buf = util::alloc_boxed_array::<CRYPTO_PUBLICKEYBYTES>();
     let mut secret_key_buf = util::alloc_boxed_array::<CRYPTO_SECRETKEYBYTES>();
@@ -503,7 +507,6 @@ pub fn encapsulate<'shared_secret, R: CryptoRng + Rng>(
 /// Convenient wrapper around [`encapsulate`] that stores the shared secret on the heap
 /// and returns it with the ``'static`` lifetime.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn encapsulate_boxed<R: CryptoRng + Rng>(
     public_key: &PublicKey<'_>,
     rng: &mut R,
@@ -544,7 +547,6 @@ pub fn decapsulate<'shared_secret>(
 /// Convenient wrapper around [`decapsulate`] that stores the shared secret on the heap
 /// and returns it with the ``'static`` lifetime.
 #[cfg(feature = "alloc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decapsulate_boxed(ciphertext: &Ciphertext, secret_key: &SecretKey) -> SharedSecret<'static> {
     let mut shared_secret_buf = KeyBufferMut::Owned(Box::new([0u8; CRYPTO_BYTES]));
 

--- a/lib-q-core/src/wasm/conversions.rs
+++ b/lib-q-core/src/wasm/conversions.rs
@@ -45,7 +45,7 @@ impl WasmConversions {
         array
     }
 
-    /// Convert WASM Uint8Array to Rust Vec<u8>
+    /// Convert WASM `Uint8Array` to Rust `Vec<u8>`
     ///
     /// Validates input size to limit abuse; copies array contents into a new `Vec`.
     pub fn uint8array_to_vec(array: &Uint8Array) -> Result<Vec<u8>> {

--- a/lib-q-core/src/wasm_common.rs
+++ b/lib-q-core/src/wasm_common.rs
@@ -125,14 +125,14 @@ pub mod conversions {
 
     use js_sys::Uint8Array;
 
-    /// Convert Rust Vec<u8> to WASM Uint8Array
+    /// Convert Rust `Vec<u8>` to WASM `Uint8Array`
     pub fn vec_to_uint8array(data: &[u8]) -> Uint8Array {
         let array = Uint8Array::new_with_length(data.len() as u32);
         array.copy_from(data);
         array
     }
 
-    /// Convert WASM Uint8Array to Rust Vec<u8>
+    /// Convert WASM `Uint8Array` to Rust `Vec<u8>`
     pub fn uint8array_to_vec(array: &Uint8Array) -> Vec<u8> {
         let length = array.length() as usize;
         let mut vec = alloc::vec![0u8; length];

--- a/lib-q-dkg/src/lattice/mod.rs
+++ b/lib-q-dkg/src/lattice/mod.rs
@@ -1,13 +1,13 @@
 //! Self-contained lattice machinery for the binding dealerless DKG.
 //!
 //! Layers (built bottom-up, each independently tested):
-//! 1. [`gaussian`] — discrete Gaussian sampler `D_{Z,s,c}` (FS-proof mask).
-//! 2. [`ring`] — `R_q = Z_q[X]/(X^N+1)` (`N = 1024`, `q ≈ 2^48`) negacyclic NTT.
-//! 3. [`bdlop`] — BDLOP commitment (message-in-clear, statistically binding) + the Fiat–Shamir
+//! 1. [`gaussian`](crate::lattice::gaussian) — discrete Gaussian sampler `D_{Z,s,c}` (FS-proof mask).
+//! 2. [`ring`](crate::lattice::ring) — `R_q = Z_q[X]/(X^N+1)` (`N = 1024`, `q ≈ 2^48`) negacyclic NTT.
+//! 3. [`bdlop`](crate::lattice::bdlop) — BDLOP commitment (message-in-clear, statistically binding) + the Fiat–Shamir
 //!    proof of correct sharing that makes the no-dealer check bind the share *value*.
 //!
 //! The subtree is `no_std + alloc`-capable (`f64` math comes from `libm` when `std` is off — see
-//! [`fmath`]; lazy tables use `once_cell::race`) and **research-grade**: samplers are not
+//! the crate-private `fmath` module; lazy tables use `once_cell::race`) and **research-grade**: samplers are not
 //! constant-time. See the crate `LIBQ_API.md` for the scheme choice and RED-zone caveats.
 
 // Index-based loops are the natural expression for the matrix/vector math here.

--- a/lib-q-dkg/src/lattice/ring.rs
+++ b/lib-q-dkg/src/lattice/ring.rs
@@ -323,7 +323,7 @@ pub fn poly_from_i64(coeffs: &[i64; N]) -> Rq {
 ///
 /// **Branchless**: the decapsulation path calls this on the secret decode input `w`, so the
 /// conditional subtract of `q` must not branch on the coefficient value (same discipline as
-/// [`csub_q_u64`]). `rem_euclid` by the constant `Q` compiles to a multiply-shift, not a division.
+/// `csub_q_u64`). `rem_euclid` by the constant `Q` compiles to a multiply-shift, not a division.
 #[must_use]
 pub fn centered_coeffs(p: &Rq) -> [i64; N] {
     let half = Q / 2;

--- a/lib-q-fn-dsa/src/lib.rs
+++ b/lib-q-fn-dsa/src/lib.rs
@@ -220,13 +220,13 @@ impl FnDsa512 {
 
     /// Deterministically generate a keypair from a 32-byte seed (reproducible KAT / identity
     /// derivation). The seed MUST be fresh CSPRNG entropy in production; see
-    /// [`keygen_from_seed_bytes`].
+    /// `keygen_from_seed_bytes`.
     pub fn generate_keypair_from_seed(&self, seed: &[u8; 32]) -> Result<SigKeypair> {
         keygen_from_seed_bytes(FN_DSA_LOGN_512, seed)
     }
 
     /// Deterministically sign `message` from a 32-byte seed. Production callers pass fresh CSPRNG
-    /// entropy per signature; a fixed seed reproduces a KAT signature. See [`sign_from_seed_bytes`].
+    /// entropy per signature; a fixed seed reproduces a KAT signature. See `sign_from_seed_bytes`.
     pub fn sign_from_seed(
         &self,
         secret_key: &SigSecretKey,
@@ -344,13 +344,13 @@ impl FnDsa1024 {
 
     /// Deterministically generate a keypair from a 32-byte seed (reproducible KAT / identity
     /// derivation). The seed MUST be fresh CSPRNG entropy in production; see
-    /// [`keygen_from_seed_bytes`].
+    /// `keygen_from_seed_bytes`.
     pub fn generate_keypair_from_seed(&self, seed: &[u8; 32]) -> Result<SigKeypair> {
         keygen_from_seed_bytes(FN_DSA_LOGN_1024, seed)
     }
 
     /// Deterministically sign `message` from a 32-byte seed. Production callers pass fresh CSPRNG
-    /// entropy per signature; a fixed seed reproduces a KAT signature. See [`sign_from_seed_bytes`].
+    /// entropy per signature; a fixed seed reproduces a KAT signature. See `sign_from_seed_bytes`.
     pub fn sign_from_seed(
         &self,
         secret_key: &SigSecretKey,

--- a/lib-q-hash/src/cshake.rs
+++ b/lib-q-hash/src/cshake.rs
@@ -189,7 +189,6 @@ macro_rules! impl_cshake {
             }
         }
 
-        #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
         #[cfg(feature = "zeroize")]
         impl digest::zeroize::ZeroizeOnDrop for $name {}
 

--- a/lib-q-hqc/src/simd/avx2/gf2x.rs
+++ b/lib-q-hqc/src/simd/avx2/gf2x.rs
@@ -2,7 +2,8 @@
 //!
 //! Port of [`reference/hqc/src/x86_64/common/hqc-*/gf2x.c`](../../../../../../reference/hqc/src/x86_64/common/hqc-1/gf2x.c):
 //! **Toom–Cook 3-way**, recursive **Karatsuba**, **PCLMUL**, then **reduce**, parameterized by
-//! [`HqcParams::PARAM_N_MULT`] and [`HqcParams::VEC_N_256_SIZE_64`].
+//! [`HqcParams::PARAM_N_MULT`](crate::HqcParams::PARAM_N_MULT) and
+//! [`HqcParams::VEC_N_256_SIZE_64`](crate::HqcParams::VEC_N_256_SIZE_64).
 //!
 //! # Safety
 //!

--- a/lib-q-hqc/src/simd/avx2/polynomial.rs
+++ b/lib-q-hqc/src/simd/avx2/polynomial.rs
@@ -50,7 +50,7 @@ use core::arch::x86_64::{
 /// * `sparse` - Sparse polynomial (fixed weight, represented as bit positions)
 /// * `dense` - Dense polynomial (full representation)
 /// * `weight` - Weight of the sparse polynomial
-/// Sparse–dense product in GF(2)[x]/(x^n - 1) with correct cyclic reduction modulo `n_bits`.
+/// Sparse–dense product in `GF(2)[x]/(x^n - 1)` with correct cyclic reduction modulo `n_bits`.
 ///
 /// Uses the same bit-accurate reference as [`super::super::portable::sparse_dense_mul_portable`].
 /// AVX2-accelerated cyclic shifts can be layered in later without changing this API.

--- a/lib-q-k12/src/lib.rs
+++ b/lib-q-k12/src/lib.rs
@@ -4,7 +4,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, unreachable_pub)]
 

--- a/lib-q-keccak-digest/src/lib.rs
+++ b/lib-q-keccak-digest/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! # Security
 //!
-//! - [`Keccak256`](crate::Keccak256) and any [`lib_q_sha3::Sha3_256`](https://docs.rs/lib-q-sha3) produce **different** digests for the same input (different padding).
+//! - [`Keccak256`] and any [`lib_q_sha3::Sha3_256`](https://docs.rs/lib-q-sha3) produce **different** digests for the same input (different padding).
 //! - Do not substitute this crate for SHA-3 in a protocol without explicit specification.
 //!
 //! See the crate **README** for links, architecture ADR, and follow-up dependency extraction ADR.

--- a/lib-q-keccak/src/lib.rs
+++ b/lib-q-keccak/src/lib.rs
@@ -25,7 +25,6 @@
 //! To disable loop unrolling (e.g. for constraint targets) use the `no_unroll` feature.
 
 #![cfg_attr(keccak_portable_simd, feature(portable_simd))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/Enkom-Tech/libQ/main/docs/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/Enkom-Tech/libQ/main/docs/logo.svg"

--- a/lib-q-lattice-zkp/src/blind.rs
+++ b/lib-q-lattice-zkp/src/blind.rs
@@ -259,7 +259,7 @@ struct BlindOpeningSecrets {
 
 /// User-side state after [`BlindIssuance::request`].
 ///
-/// Dropping without finalizing scrubs [`BlindOpeningSecrets`] automatically.
+/// Dropping without finalizing scrubs `BlindOpeningSecrets` automatically.
 #[must_use = "consume via BlindIssuance::finalize or drop to scrub blind/user openings"]
 #[derive(Clone)]
 pub struct BlindUserState {
@@ -308,7 +308,7 @@ pub struct BlindResponse {
 
 /// Final bundle after [`BlindIssuance::finalize`].
 ///
-/// Cloning duplicates the secret [`token_opening`]; prefer references when possible.
+/// Cloning duplicates the secret [`token_opening`](Self::token_opening); prefer references when possible.
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct UnblindedIssuance {
     #[zeroize(skip)]

--- a/lib-q-lattice-zkp/src/challenge.rs
+++ b/lib-q-lattice-zkp/src/challenge.rs
@@ -1,7 +1,7 @@
 //! ML-DSA–compatible sparse ternary challenges.
 //!
 //! Sigma opening / linear / PVTN Fiat–Shamir uses the QROM committed-first-message transcript in
-//! [`crate::sigma::opening`](crate::sigma::opening) (`fs_w_digest`, then `SHAKE256(ctx ‖ w_digest)`).
+//! [`crate::sigma::opening`] (`fs_w_digest`, then `SHAKE256(ctx ‖ w_digest)`).
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;

--- a/lib-q-lattice-zkp/src/hardened.rs
+++ b/lib-q-lattice-zkp/src/hardened.rs
@@ -4,9 +4,9 @@
 //!
 //! - Constant-time infinity-norm screening via [`lib_q_ring::polys_norm_within_bound`].
 //! - First-order additive witness masking before `c·wit` ring multiplies
-//!   ([`crate::sigma::secrets::MaskedWitness`]).
+//!   (`crate::sigma::secrets::MaskedWitness`).
 //! - Fixed-iteration rejection loops: every attempt runs norm screen + verification; the first
-//!   accepting transcript is merged with [`ct_select_polys`] (no early return on success).
+//!   accepting transcript is merged with `ct_select_polys` (no early return on success).
 //!
 //! # Rejection-attempt counts
 //!

--- a/lib-q-ml-kem/src/lib.rs
+++ b/lib-q-ml-kem/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo.svg",

--- a/lib-q-ml-kem/src/wasm.rs
+++ b/lib-q-ml-kem/src/wasm.rs
@@ -11,11 +11,11 @@
 //!
 //! Decapsulation keys and shared secrets are stored in [`zeroize::Zeroizing`] buffers so they are
 //! cleared on drop when WASM objects are garbage-collected on the Rust side. Serialized key bytes
-//! from [`EncodedSizeUser::as_bytes`](crate::EncodedSizeUser::as_bytes) use the same `Zeroizing`
+//! from [`EncodedSizeUser::as_bytes`] use the same `Zeroizing`
 //! pattern.
 //!
 //! Secret bytes are copied to `JavaScript` as [`js_sys::Uint8Array`] via `copy_from` (not as an owned
-//! non-zeroizing [`alloc::vec::Vec`] return), which avoids an extra full-size plaintext `Vec` in
+//! non-zeroizing `alloc::vec::Vec` return), which avoids an extra full-size plaintext `Vec` in
 //! Rust linear memory for each getter or decapsulate call.
 //!
 //! **`JavaScript` callers** must still treat returned `Uint8Array` values as sensitive: Rust cannot

--- a/lib-q-ring-sig/src/dualring_prf.rs
+++ b/lib-q-ring-sig/src/dualring_prf.rs
@@ -223,7 +223,7 @@ pub fn dualring_prf_verify_u256(
 /// otherwise this returns [`DualringPrfError::Rejected`],
 /// avoiding a timing signal correlated with which batch index failed first. Per-item failures
 /// that would surface as [`DualringPrfError::Prf`] or [`DualringPrfError::InvalidInput`]
-/// in single-item verify are folded into that aggregate [`Rejected`] outcome.
+/// in single-item verify are folded into that aggregate [`Rejected`](DualringPrfError::Rejected) outcome.
 #[must_use = "batch verification outcome must be checked"]
 pub fn verify_dualring_prf_batch_u256(
     ring: &[DualringPrfMemberSecrets256],

--- a/lib-q-ring/src/wasm.rs
+++ b/lib-q-ring/src/wasm.rs
@@ -15,7 +15,7 @@ pub fn ring_coefficient_count() -> u32 {
     COEFFICIENTS_IN_RING_ELEMENT as u32
 }
 
-/// Modulus `q` for \(R_q = Z_q[X]/(X^{256}+1)\).
+/// Modulus `q` for `R_q = Z_q[X]/(X^256+1)`.
 #[wasm_bindgen(js_name = ringModulusQ)]
 pub fn ring_modulus_q() -> u32 {
     FIELD_MODULUS as u32

--- a/lib-q-rocca-s/src/lib.rs
+++ b/lib-q-rocca-s/src/lib.rs
@@ -25,6 +25,13 @@
 //! **Constant-time note:** the scalar fallback uses a table-based S-box and is not
 //! constant-time. The hardware backends are constant-time. See `SECURITY.md`.
 //!
+//! ## Cargo features
+//!
+//! - `aead` + `alloc` (both, and both on by default) — gate [`RoccaSAead`], the
+//!   allocating AEAD wrapper. Without them only the borrowed-buffer API is built.
+//! - `std` — enables runtime CPU detection for the hardware AES backends.
+//! - `simd` / `simd-aesni` / `simd-neon` — hardware AES round (imply `std`).
+//!
 //! ## Example
 //!
 //! ```rust
@@ -49,7 +56,6 @@
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/lib-q-saturnin/src/aead_short.rs
+++ b/lib-q-saturnin/src/aead_short.rs
@@ -34,7 +34,7 @@
 //! assembly). As with the full Saturnin AEAD path in `aead.rs` (constant-time tag check over
 //! the binding, then full CTR on the ciphertext, then map the outcome), the closing step maps
 //! the verification result to `Ok` versus
-//! `Err(Error::VerificationFailed)`; [`AeadDecryptSemantic`](lib_q_core::AeadDecryptSemantic)
+//! `Err(Error::VerificationFailed)`; [`AeadDecryptSemantic`]
 //! exposes `Ok(AuthenticationFailed)` instead for Layer B. A public `Result` API cannot
 //! expose both outcomes without that discriminant. Treat verification timing under the same
 //! remote-adversary assumptions as full AEAD unless a higher layer enforces additional timing

--- a/lib-q-saturnin/src/tbc.rs
+++ b/lib-q-saturnin/src/tbc.rs
@@ -49,7 +49,7 @@ impl SaturninTbc {
     /// Create a TBC instance for the given 4-bit domain separator.
     ///
     /// # Errors
-    /// Returns [`Error::InvalidAlgorithm`] if `domain > 15`.
+    /// Returns [`lib_q_core::Error::InvalidAlgorithm`] if `domain > 15`.
     pub fn new(domain: u8) -> Result<Self> {
         let core = SaturninCore::new(TBC_SUPER_ROUNDS, domain)?;
         Ok(Self { core, domain })

--- a/lib-q-sha3/src/block_core.rs
+++ b/lib-q-sha3/src/block_core.rs
@@ -2,9 +2,9 @@
 //!
 //! - [`SpongeHasherCore`]: generic sponge core (rate, output width, padding nibble, round count) backing SHA-3, SHAKE, cSHAKE, TurboSHAKE in this crate; pre-FIPS Keccak digests use the same core via [`lib-q-keccak-digest`](https://github.com/Enkom-Tech/libQ/tree/main/lib-q-keccak-digest).
 //! - [`SpongeReaderCore`]: XOF output phase for Keccak-based XOFs.
-//! - `CShake128Core` / `CShake256Core` (re-exported from the [`cshake`](crate::cshake) module): cSHAKE without the `buffer_xof!` wrapper—only needed for trees or custom plumbing.
+//! - `CShake128Core` / `CShake256Core` (re-exported from the [`cshake`] module): cSHAKE without the `buffer_xof!` wrapper—only needed for trees or custom plumbing.
 //!
-//! For normal hashing, use the crate-root types ([`Sha3_256`], [`Shake128`], [`CShake128`](crate::CShake128)) or the separate [`lib-q-k12`](https://github.com/Enkom-Tech/libQ/tree/main/lib-q-k12) crate for KangarooTwelve. Manipulating cores directly is a **hazmat**-style API: incorrect padding or rate breaks security.
+//! For normal hashing, use the crate-root types ([`Sha3_256`], [`Shake128`], [`CShake128`]) or the separate [`lib-q-k12`](https://github.com/Enkom-Tech/libQ/tree/main/lib-q-k12) crate for KangarooTwelve. Manipulating cores directly is a **hazmat**-style API: incorrect padding or rate breaks security.
 
 use core::fmt;
 use core::marker::PhantomData;
@@ -230,7 +230,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 #[cfg(feature = "zeroize")]
 impl<Rate, OutputSize, const PAD: u8, const ROUNDS: usize> digest::zeroize::ZeroizeOnDrop
     for SpongeHasherCore<Rate, OutputSize, PAD, ROUNDS>
@@ -341,7 +340,6 @@ where
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
 #[cfg(feature = "zeroize")]
 impl<Rate, const ROUNDS: usize> digest::zeroize::ZeroizeOnDrop for SpongeReaderCore<Rate, ROUNDS> where
     Rate: BlockSizes + IsLessOrEqual<U200, Output = True>

--- a/lib-q-sha3/src/cshake.rs
+++ b/lib-q-sha3/src/cshake.rs
@@ -1,6 +1,6 @@
 //! cSHAKE-128 and cSHAKE-256 per [NIST SP 800-185](https://csrc.nist.gov/pubs/sp/800/185/final).
 //!
-//! The **function name** and **customization string** (NIST “N” and “S”) are encoded in the sponge state before message data. If both are empty, cSHAKE reduces to SHAKE for that rate (per the standard). The high-level types [`CShake128`](crate::CShake128) and [`CShake256`](crate::CShake256) are re-exported at the crate root.
+//! The **function name** and **customization string** (NIST “N” and “S”) are encoded in the sponge state before message data. If both are empty, cSHAKE reduces to SHAKE for that rate (per the standard). The high-level types [`CShake128`] and [`CShake256`] are re-exported at the crate root.
 //!
 //! Internal **core** types (`CShake128Core`, `CShake256Core`) support [`digest::common::hazmat::SerializableState`](https://docs.rs/digest/latest/digest/common/hazmat/trait.SerializableState.html) for advanced use; prefer the façade types for normal hashing.
 
@@ -190,7 +190,6 @@ macro_rules! impl_cshake {
             }
         }
 
-        #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
         #[cfg(feature = "zeroize")]
         impl digest::zeroize::ZeroizeOnDrop for $name {}
 

--- a/lib-q-sha3/src/lib.rs
+++ b/lib-q-sha3/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Re-exports
 //!
 //! - [`digest`]: the `digest` crate (version unified with the workspace).
-//! - [`Digest`], [`Update`], [`ExtendableOutput`], [`ExtendableOutputReset`], [`XofReader`], [`CustomizedInit`], [`CollisionResistance`]: common [`digest`](https://docs.rs/digest) traits, re-exported at the root. For XOFs use [`Update`], [`ExtendableOutput`], and [`XofReader`]. If a module imports both [`Digest`] and [`Update`], disambiguate [`Digest::update`](Digest::update) and [`Update::update`](Update::update) with explicit trait paths.
+//! - [`Digest`], [`Update`], [`ExtendableOutput`], [`ExtendableOutputReset`], [`XofReader`], [`CustomizedInit`], [`CollisionResistance`]: common [`digest`](https://docs.rs/digest) traits, re-exported at the root. For XOFs use [`Update`], [`ExtendableOutput`], and [`XofReader`]. If a module imports both [`Digest`] and [`Update`], disambiguate [`Digest::update`] and [`Update::update`] with explicit trait paths.
 //!
 //! # Modules
 //!
@@ -16,8 +16,8 @@
 //! # Crate features
 //!
 //! Optional Cargo features: `alloc`, `oid`, `zeroize`, `asm` (see the README *Feature flags* table).
-//! On [docs.rs](https://docs.rs/lib-q-sha3), this crate is built with `all-features`; the `doc_cfg`
-//! rustdoc feature marks APIs that require a Cargo feature. The `zeroize` feature enables
+//! On [docs.rs](https://docs.rs/lib-q-sha3), this crate is built with `all-features`; rustdoc
+//! marks APIs that require a Cargo feature automatically. The `zeroize` feature enables
 //! [`ZeroizeOnDrop`](https://docs.rs/digest/latest/digest/trait.ZeroizeOnDrop.html) (from the `zeroize` feature) on supported types.
 //!
 //! # `sha3_256` vs `Sha3_256`
@@ -30,7 +30,6 @@
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/6ee8e381/logo.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations)]
 

--- a/lib-q-sha3/src/parallel.rs
+++ b/lib-q-sha3/src/parallel.rs
@@ -7,7 +7,7 @@
 //! small, fixed-function primitive.
 //!
 //! The result is **bit-for-bit identical** to running four scalar
-//! [`TurboShake128`](crate::TurboShake128) / [`TurboShake256`](crate::TurboShake256)
+//! [`TurboShake128`] / [`TurboShake256`]
 //! instances; on targets without AVX2 the underlying permutation simply falls
 //! back to four scalar permutations, so output never changes.
 //!

--- a/lib-q-sha3/src/turbo_shake.rs
+++ b/lib-q-sha3/src/turbo_shake.rs
@@ -1,6 +1,6 @@
 //! TurboSHAKE-128 and TurboSHAKE-256: Keccak-`p` with a **domain byte** `DS` (`0x01`..=`0x7F`) and 12 rounds (see [RFC 9861](https://www.rfc-editor.org/rfc/rfc9861.html) and the KangarooTwelve document). Used as the leaf primitive in [`lib_q_k12`](https://github.com/Enkom-Tech/libQ/tree/main/lib-q-k12).
 //!
-//! Use **distinct** `DS` values for independent protocols. [`TurboShake128`](crate::TurboShake128) and [`TurboShake256`](crate::TurboShake256) are re-exported at the crate root.
+//! Use **distinct** `DS` values for independent protocols. [`TurboShake128`] and [`TurboShake256`] are re-exported at the crate root.
 
 use core::fmt;
 
@@ -118,7 +118,6 @@ macro_rules! impl_turbo_shake {
             }
         }
 
-        #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
         #[cfg(feature = "zeroize")]
         impl<const DS: u8> digest::zeroize::ZeroizeOnDrop for $name<DS> {}
 

--- a/lib-q-stark-field-testing/Cargo.toml
+++ b/lib-q-stark-field-testing/Cargo.toml
@@ -28,6 +28,11 @@ criterion-bench = ["criterion"]
 
 [package.metadata.docs.rs]
 features = ["criterion-bench"]
+# Every other published crate in this workspace sets `--cfg docsrs` here; this one was
+# missing it, so a future `cfg_attr(docsrs, ...)` added to this crate would silently never
+# see docsrs cfg on the real docs.rs build (the same class of gap that let four other
+# crates ship broken docs.rs builds undetected). Keep in sync with the workspace default.
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/lib-q-threshold-kem-lattice/src/kem.rs
+++ b/lib-q-threshold-kem-lattice/src/kem.rs
@@ -243,7 +243,7 @@ fn ct_digest(ct: &Ciphertext) -> [u8; 32] {
 /// Public accessor for the public-key digest of `t0` — `pk_digest(t0)`, the value absorbed into the
 /// FO seed `SHAKE256(dom ‖ pk_digest ‖ μ)`. Exposed so an encryption-proof **verifier** (which holds
 /// `t0` but never the witness) can rebuild the sponge's pk-binding public values itself, rather than
-/// trusting a prover-supplied digest. Thin wrapper over the internal [`pk_digest`].
+/// trusting a prover-supplied digest. Thin wrapper over the internal `pk_digest`.
 #[must_use]
 pub fn pk_digest_of(t0: &[Rq]) -> [u8; 32] {
     pk_digest(t0)

--- a/lib-q-threshold-kem-lattice/src/threshold.rs
+++ b/lib-q-threshold-kem-lattice/src/threshold.rs
@@ -123,7 +123,7 @@ impl DecapBudget {
 
 /// Symmetric pairwise seeds for the additive zero-sharing (one per unordered party pair).
 ///
-/// In a deployment these come from pairwise key agreement during/after the DKG; the [`setup`] helper
+/// In a deployment these come from pairwise key agreement during/after the DKG; the [`setup`](Self::setup) helper
 /// samples them for testing. `seed(i, j) == seed(j, i)`.
 ///
 /// The per-pair seed bytes are **secret** (they key the zero-share PRF), so the set zeroizes them on
@@ -161,7 +161,7 @@ impl ZeroShareSeeds {
     /// each `seed_ij` comes from pairwise key agreement established during the DKG (a shared secret only
     /// parties `i` and `j` can compute), rather than the random [`setup`](Self::setup) test source. Each
     /// entry is the canonical unordered pair `(i, j, seed)` with `0 < i < j`; a zero index, `i >= j`, or a
-    /// duplicate pair is rejected ([`ThresholdKemError::InvalidSeedEntry`]) so [`seed`](Self::seed) lookup
+    /// duplicate pair is rejected ([`ThresholdKemError::InvalidSeedEntry`]) so `seed` lookup
     /// is unambiguous and fail-closed. The seed bytes must be a *secret* shared by exactly `i` and `j`;
     /// deriving them from public material would forfeit the per-broadcast uniformity the zero-share
     /// provides (see the module security notes).

--- a/lib-q-transcript/src/k12.rs
+++ b/lib-q-transcript/src/k12.rs
@@ -2,7 +2,7 @@
 //!
 //! [`K12Transcript`] realises the [`DuplexTranscript`] discipline with `Unit = u8`. It is the layer
 //! that prover/verifier code uses to derive challenges on the wire. Every hash is a `Kt128` with an
-//! **empty customization string** and the instantiation label ([`labels::K12_TRANSCRIPT_V0`]) as a
+//! **empty customization string** and the instantiation label ([`labels::K12_TRANSCRIPT_V0`](crate::labels::K12_TRANSCRIPT_V0)) as a
 //! **leading message prefix** — the lib-Q KangarooTwelve domain-separation discipline.
 
 use alloc::vec;

--- a/lib-q-zk-encryption-proof/src/compose.rs
+++ b/lib-q-zk-encryption-proof/src/compose.rs
@@ -25,7 +25,7 @@
 //! Validated end-to-end through `prove_batch`/`verify_batch` (cryptographic enforcement via the batch
 //! verifier's `verify_global_final_value`, not merely the debug `check_lookups`):
 //!   * the composition primitives — a `Kind::Global` cross-table lookup between two heterogeneous AIR
-//!     instances, and a **preprocessed** column feeding a lookup (via [`build_preprocessed`]);
+//!     instances, and a **preprocessed** column feeding a lookup (via `build_preprocessed`);
 //!   * the **byte-provenance chain** (join 1) — sponge (68 limb-Sends + preprocessed position column) ⇒
 //!     squeeze-byte table (limb-Receive + consumed-prefix byte-Send) ⇒ sampler (byte-Receive), verifying
 //!     iff the sampler consumed the genuine SHAKE output; a sponge proving a *different* μ is rejected;
@@ -38,7 +38,7 @@
 //!     instances carry two lookup groups (e.g. the fold's coeff-Receive on aux cols 0..4 + its `E`-Send
 //!     on cols 4..8) without collision, via each join constructor's `col_base`.
 //!
-//! Building [`prove_batch`]-with-lookups surfaced (and this crate fixed) a real degree-under-count bug
+//! Building `prove_batch`-with-lookups surfaced (and this crate fixed) a real degree-under-count bug
 //! in `lib-q-plonky-lookup` (the path had no end-to-end test repo-wide).
 //!
 //! **Status of #26 (COMPLETE, 2026-07-14):** the full byte-provenance composition has been **lifted out

--- a/lib-q-zk-encryption-proof/src/lib.rs
+++ b/lib-q-zk-encryption-proof/src/lib.rs
@@ -1,5 +1,5 @@
 //! ZK-STARK proof of correct encryption (proof-of-knowledge of message `mu`)
-//! for [`lib-q-threshold-kem-lattice`] ciphertexts.
+//! for `lib-q-threshold-kem-lattice` ciphertexts.
 //!
 //! **Status: RED/unsigned — research add-on, not reviewed, not production-ready.**
 //!

--- a/lib-q-zk-encryption-proof/src/sampler.rs
+++ b/lib-q-zk-encryption-proof/src/sampler.rs
@@ -894,14 +894,14 @@ pub fn ternary_receive_lookup_at(offset: u64) -> Lookup<ConfigVal> {
 /// Join-2 **Send** lookups the ternary sampler contributes (design §5, coefficient binding): on every
 /// **accepted** row, Send the mod-q lift of the emitted coefficient (`∈ {−1, 0, +1}`) as four 12-bit
 /// limbs on [`COEFF_E_BUS`], at position `base + 4·coeff_idx + j`. `base` locates this ring element on
-/// `e`'s coefficient axis (`4·r·N` for `e_r`; `0` for a lone element); `coeff_idx` ([`C_COEFF_IDX`]) is
+/// `e`'s coefficient axis (`4·r·N` for `e_r`; `0` for a lone element); `coeff_idx` (`C_COEFF_IDX`) is
 /// the emitted coefficient's global index. The lift limbs are pure expressions in the two low byte
 /// bits — no new trace columns:
-/// * `sel_neg = (1−bit0)(1−bit1)` (`two = 0` ⇒ coeff `−1` ⇒ limbs = `q−1`'s limbs [`QM1_LIMBS`]);
+/// * `sel_neg = (1−bit0)(1−bit1)` (`two = 0` ⇒ coeff `−1` ⇒ limbs = `q−1`'s limbs `QM1_LIMBS`);
 /// * `sel_one = (1−bit0)·bit1`   (`two = 2` ⇒ coeff `+1` ⇒ limb₀ = 1);
 /// * coeff `0` (`two = 1`) ⇒ all-zero limbs.
 ///
-/// Gated by [`C_EMIT`] (the first `num_coeffs` accepts only), so rejected, drained and padding rows
+/// Gated by `C_EMIT` (the first `num_coeffs` accepts only), so rejected, drained and padding rows
 /// Send nothing. The four limbs Receive into the
 /// matching [`crate::zq::HornerFoldAir`] fold's `w` limbs ([`crate::zq::horner_coeff_receive_lookups_at`]);
 /// the fold's canonicity + `w < q` checks make the binding sound (the lift is `−1 ↦ q−1`, `0 ↦ 0`,
@@ -963,11 +963,11 @@ pub fn bounded_receive_lookup_at(offset: u64) -> Vec<Lookup<ConfigVal>> {
 
 /// Join-2 **Send** lookups the bounded sampler contributes (design §5, coefficient binding): on every
 /// **accepted** row, Send the emitted coefficient's mod-q lift (`= (R − BOUND) mod Q`) as its four
-/// witnessed 12-bit [`W_LIFT`] limbs on `bus`, at position `base + 4·coeff_idx + j`. `bus` is the
+/// witnessed 12-bit `W_LIFT` limbs on `bus`, at position `base + 4·coeff_idx + j`. `bus` is the
 /// component's coefficient bus ([`COEFF_F_BUS`](crate::logup_join::COEFF_F_BUS) for `f`,
 /// [`COEFF_G_BUS`](crate::logup_join::COEFF_G_BUS) for `g`); `base` locates this ring element on that
-/// axis (`4·k·N` for `f_k`; `0` for a lone `g`); `coeff_idx` ([`W_CIDX`]) is the coefficient's global
-/// index. Gated by [`W_EMIT`] (the first `num_coeffs` accepts only). The lift value and `neg` are pinned by the in-AIR
+/// axis (`4·k·N` for `f_k`; `0` for a lone `g`); `coeff_idx` (`W_CIDX`) is the coefficient's global
+/// index. Gated by `W_EMIT` (the first `num_coeffs` accepts only). The lift value and `neg` are pinned by the in-AIR
 /// `lift + BOUND = R + neg·Q` chain; the `lift < Q` bound (hence the correct `neg`) is the matching
 /// [`crate::zq::HornerFoldAir`] fold's `w < Q`, back-propagated through the multiset equality. Four
 /// single-tuple lookups (degree-3 each), mirroring the ternary and sponge-limb Sends.

--- a/lib-q-zk-encryption-proof/src/sponge_air.rs
+++ b/lib-q-zk-encryption-proof/src/sponge_air.rs
@@ -21,7 +21,8 @@
 //!   `first_step: preimage == a`, this threads the running sponge state across permutations.
 //!
 //! ## Soundness scope / status (RED)
-//! Both constraint groups are validated by [`check_constraints`](lib_q_stark::check_constraints) on
+//! Both constraint groups are validated by `lib_q_stark::check_constraints` (a `lib-q-stark`
+//! dev-dependency helper, not linkable from the public API doc) on
 //! the **truncated** (exactly `24·num_perms`-row, unpadded) trace produced by [`generate_sponge_air_trace`]:
 //! every `step_flags[23]` boundary there is a *real* inter-block boundary, and the final one is
 //! excluded by `is_transition`. A STARK `prove`/`verify` runs over the power-of-two-height trace from
@@ -274,15 +275,15 @@ impl<AB: AirBuilder<F = ConfigVal>> Air<AB> for ShakeSpongeAir {
     }
 }
 
-/// The [`RATE_LIMBS`] (= 68) per-rate-limb **Send** lookups the sponge contributes on
+/// The `RATE_LIMBS` (= 68) per-rate-limb **Send** lookups the sponge contributes on
 /// [`SQUEEZE_LIMB_BUS`] — the limb half of design join 1. For each rate limb `i`, Send
 /// `(RATE_BYTES·perm + 2·i, a‴_limb_i)` gated by the final-step selector `step_flags[NUM_ROUNDS-1]`:
 ///   * `RATE_BYTES·perm` is the preprocessed position column (col 0) — the squeeze-block byte offset;
 ///   * `2·i` is the per-limb constant offset (rate limb `i` covers output bytes `2i, 2i+1`);
 ///   * the sent value is the output-limb column `output_limb(i)` (the 16-bit `a‴` limb);
-///   * the multiplicity is main column [`STEP_LAST_COL`] (1 only on final-step rows).
+///   * the multiplicity is main column `STEP_LAST_COL` (1 only on final-step rows).
 ///
-/// Each lookup uses its own aux column `i`, so the sponge's permutation trace has [`RATE_LIMBS`]
+/// Each lookup uses its own aux column `i`, so the sponge's permutation trace has `RATE_LIMBS`
 /// columns. They are deliberately **single-tuple** (degree 3): one bundled 68-tuple lookup would
 /// have a 68-fold product denominator (degree ~69), blowing up the quotient domain.
 ///
@@ -336,7 +337,7 @@ pub fn sponge_public_values(pk_digest: &[u8; 32]) -> Vec<ConfigVal> {
 }
 
 /// Generate the **truncated** SHAKE-256 sponge trace — exactly `24·num_perms` rows, with no
-/// power-of-two zero-input padding — embedded into the STARK value field, for [`check_constraints`]
+/// power-of-two zero-input padding — embedded into the STARK value field, for `check_constraints`
 /// validation of [`ShakeSpongeAir`]. (The `prove`-time padded trace additionally needs the boundary
 /// selector; see the module docs.)
 pub fn generate_sponge_air_trace(input: &[u8], out_len: usize) -> RowMajorMatrix<ConfigVal> {

--- a/lib-q-zk-encryption-proof/src/zq.rs
+++ b/lib-q-zk-encryption-proof/src/zq.rs
@@ -682,7 +682,7 @@ pub fn horner_public_values(zeta: u64) -> Vec<ConfigVal> {
 
 /// Join-2 **Receive** lookups the fold contributes (design §5, coefficient binding): four single-limb
 /// `(position, w_limb)` tuples per row on `bus`, at absolute coefficient-limb position
-/// `base + 4·idx + j` where `idx` is [`HW_IDX`] (this row's ζ-power / coefficient degree) and
+/// `base + 4·idx + j` where `idx` is `HW_IDX` (this row's ζ-power / coefficient degree) and
 /// `base = 4·r·N` locates ring element `r` on the component's coefficient axis (`base = 0` for a lone
 /// ring element). One single-tuple lookup per limb (degree-3 constraint) rather than one 4-tuple
 /// lookup. **Every row Receives** (no gate): the fold height must equal its coefficient count `N`
@@ -707,10 +707,10 @@ pub fn horner_coeff_receive_lookups_at(bus: &str, base: u64) -> Vec<Lookup<Confi
 
 /// Join-3 **Send** lookups the fold contributes (design §4.1, the boundary opening): four single-limb
 /// `(position, r_limb)` tuples exposing the fold RESULT `E` (the last row's remainder `r` = the fold
-/// value) on `bus`, at position `base + 4·term + limb`, gated by [`HW_ISLAST`] (so exactly one copy of
+/// value) on `bus`, at position `base + 4·term + limb`, gated by `HW_ISLAST` (so exactly one copy of
 /// `E` is Sent). `term` is this fold's index `j` among the relation's witness terms; `base`
 /// distinguishes relation instances on the shared bus. The matching [`RelationCheckAir`] Receives it
-/// into `w_term` ([`relation_w_receive_lookups_at`]). Single-tuple lookups (degree-3). This closes the
+/// into `w_term` ([`relation_w_receive_lookups_at`](RelationCheckAir::relation_w_receive_lookups_at)). Single-tuple lookups (degree-3). This closes the
 /// "expose the result" composition obligation the standalone fold cannot self-supply.
 ///
 /// `col_base` is the first **permutation aux-column index** these four lookups occupy; a fold that also

--- a/lib-q-zkp/src/air/wide_hash.rs
+++ b/lib-q-zkp/src/air/wide_hash.rs
@@ -25,8 +25,8 @@
 //!     M2** (the multi-row sponge AIR); here it is the value-level reference only.
 //!
 //! * **Circuit level:** the test fixture `WideHashPermAir` exercises
-//!   [`PoseidonGadget::with_params`]`(Poseidon256::params())` +
-//!   [`PoseidonGadget::constrain_full_state_wide`] binding 5 outputs, proving the
+//!   [`PoseidonGadget::with_params`](crate::air::poseidon_gadget::PoseidonGadget::with_params)`(Poseidon256::params())` +
+//!   [`PoseidonGadget::constrain_full_state_wide`](crate::air::poseidon_gadget::PoseidonGadget::constrain_full_state_wide) binding 5 outputs, proving the
 //!   wide-output constraint path is sound end-to-end. The multi-row sponge AIR (M2)
 //!   repeats exactly this per-row primitive with capacity carry.
 //!
@@ -58,7 +58,7 @@ pub type WideDigest = [PoseidonField; WIDE_DIGEST_ELEMS];
 /// [`WideDigest`] (first [`WIDE_DIGEST_ELEMS`] state cells).
 ///
 /// This is the per-permutation compression the in-circuit gadget path constrains
-/// ([`PoseidonGadget::constrain_full_state_wide`]) and the unit the multi-row sponge AIR
+/// ([`PoseidonGadget::constrain_full_state_wide`](crate::air::poseidon_gadget::PoseidonGadget::constrain_full_state_wide)) and the unit the multi-row sponge AIR
 /// (M2) stacks with capacity carry.
 ///
 /// `initial_state` must contain at least `state_width` (= 7) elements; only the first 7

--- a/lib-q-zkp/src/membership.rs
+++ b/lib-q-zkp/src/membership.rs
@@ -80,7 +80,7 @@ pub const CTX_BYTES: usize = CTX_ELEMS * 8; // 16
 pub const PUBLIC_STATEMENT_BYTES: usize = WIDE_DIGEST_BYTES + CTX_BYTES + WIDE_DIGEST_BYTES; // 96
 
 /// Minimum padded path depth for the hiding (zero-knowledge) prover. The STARK trace height
-/// must clear the ZK FRI minimum (`log_min_height > log_blowup`); with [`ZK_LOG_BLOWUP`] = 3,
+/// must clear the ZK FRI minimum (`log_min_height > log_blowup`); with `ZK_LOG_BLOWUP` = 3,
 /// height 8 (depth 8) is the smallest that proves. Shallow trees are padded up to this with
 /// zero siblings, exactly like the power-of-two padding.
 pub const MIN_ZK_DEPTH: usize = 8;

--- a/lib-q-zkp/src/merkle_baby_bear.rs
+++ b/lib-q-zkp/src/merkle_baby_bear.rs
@@ -1,8 +1,8 @@
 //! Wide-digest (BabyBear / Poseidon2) binary Merkle tree — the Arm B analogue of
 //! [`crate::merkle::WidePoseidonMerkleTree`].
 //!
-//! Each node is a [`WideDigestBb`] (9 BabyBear elements) and the 2-to-1 compression is
-//! [`compress_bb`] — the SAME function the membership / wide-Merkle-path AIRs constrain
+//! Each node is a [`WideDigestBb`](crate::air::wide_merkle_path_baby_bear::WideDigestBb) (9 BabyBear elements) and the 2-to-1 compression is
+//! [`compress_bb`](crate::air::wide_merkle_path_baby_bear::compress_bb) — the SAME function the membership / wide-Merkle-path AIRs constrain
 //! (`air::wide_merkle_path_baby_bear`), so a tree's `root` and `path(idx)` are exactly what the
 //! circuit proves. This lets a caller build a real membership set over BabyBear and extract an
 //! authentication path by index, at parity with Arm A (Arm B previously only synthesized single


### PR DESCRIPTION
docs.rs builds every published crate with `--all-features --cfg docsrs`. Four crates failed, so their published documentation was broken — and nothing caught it because publishing does not gate on rustdoc: `lib-q-keccak` 0.0.9 is live on crates.io **with a failed docs.rs build**.

Two causes: `doc_auto_cfg` was removed in Rust 1.92 (`lib-q-k12`, `lib-q-keccak`, `lib-q-ml-kem`), and `#[doc(cfg(...))]` used without the enabling attribute (`lib-q-hash`).

Fixed by dropping the nightly-only rustdoc attributes entirely rather than migrating them to `doc_cfg` — verified clean on **both** nightly-2026-07-24 and stable 1.97.0, so it is immune to the next round of rustdoc churn, which is the failure mode that caused this.

Also, having re-measured rather than inherited the earlier estimate: **55** doc-link warnings across 14 crates (28 unresolved intra-doc links, 22 public-links-to-private-item, 5 redundant explicit targets, and **zero** unclosed HTML tags — the previously claimed 3 do not exist). All 55 fixed, workspace-wide, without blanket `#[allow]`.

Plus: `lib-q-stark-field-testing` was missing `rustdoc-args`, and the `0.0.9`→`0.0.10` withdrawal-version error is corrected in the three docs files it had spread to.