### PR TITLE
fix(publish): derive the publish list from cd.yml and guard every restatement

### DIFF
--- a/.github/actions/crate-publish/action.yml
+++ b/.github/actions/crate-publish/action.yml
@@ -66,9 +66,33 @@ runs:
           exit 1
         fi
         
+        # `cargo publish` verifies by compiling the packaged crate in ISOLATION with the default
+        # profile (panic=unwind). A #![no_std] crate that pins lib-q-core/lib-q-platform with
+        # default-features=false (e.g. lib-q-intrinsics) drags lib-q-core into no_std, whose
+        # no_std #[panic_handler] requires panic=abort -> "unwinding panics are not supported
+        # without std". The in-workspace build is already validated in CI, so both branches fall
+        # back to --no-verify on exactly that error. They MUST agree: a dry-run that hard-fails on
+        # a crate the real publish would ship is a false alarm that trains operators to ignore it,
+        # and it fails at the one moment the dry-run exists to be trusted.
+        no_verify_fallback_needed() {
+          echo "$1" | grep -qE 'unwinding panics are not supported without std'
+        }
+
         if [ "${{ inputs.dry-run }}" = "true" ]; then
           echo "Dry run mode - would publish ${{ inputs.package }}"
-          cargo publish --allow-dirty -p "$PKG" --dry-run
+          set +e
+          publish_output="$(cargo publish --allow-dirty -p "$PKG" --dry-run 2>&1)"
+          publish_status=$?
+          set -e
+          echo "$publish_output"
+          if [ "$publish_status" -ne 0 ]; then
+            if no_verify_fallback_needed "$publish_output"; then
+              echo "::warning::$PKG failed cargo publish's isolated verify build (no_std core needs panic=abort); retrying the dry run with --no-verify (in-workspace build already verified in CI)."
+              cargo publish --allow-dirty --no-verify -p "$PKG" --dry-run
+            else
+              exit "$publish_status"
+            fi
+          fi
         else
           max_attempts=6
           attempt=1
@@ -85,13 +109,9 @@ runs:
               echo "$PKG is already on crates.io; skipping"
               break
             fi
-            # `cargo publish` verifies by compiling the packaged crate in ISOLATION with the default
-            # profile (panic=unwind). A #![no_std] crate that pins lib-q-core/lib-q-platform with
-            # default-features=false (e.g. lib-q-intrinsics) drags lib-q-core into no_std, whose
-            # no_std #[panic_handler] requires panic=abort -> "unwinding panics are not supported
-            # without std". The in-workspace build is already validated in CI, so fall back to
+            # Same no_std/panic=abort verify failure the dry-run branch handles above: fall back to
             # --no-verify (upload the packaged tarball without the isolated verify compile).
-            if echo "$publish_output" | grep -qE 'unwinding panics are not supported without std'; then
+            if no_verify_fallback_needed "$publish_output"; then
               echo "::warning::$PKG failed cargo publish's isolated verify build (no_std core needs panic=abort); retrying with --no-verify (in-workspace build already verified in CI)."
               set +e
               publish_output="$(cargo publish --allow-dirty --no-verify -p "$PKG" 2>&1)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,17 @@ jobs:
       - name: Guard banned terms in new primitive crates
         run: bash ./scripts/ci-guard-primitive-banned-terms.sh
 
+      # ci-guard-new-crates-and-npm.sh (above) checks that every workspace crate REACHES cd.yml.
+      # This one checks the other direction: that the hand-maintained restatements of cd.yml — the
+      # crates.io/npm fallback scripts an operator uses when the tag-triggered CD path is not
+      # available, and the docs/npm-publish.md package table — still say what cd.yml says. Drift
+      # there does not error at publish time; it silently ships fewer crates (65 of 80 at 0.0.10)
+      # or a package built with the wrong features, and crates.io versions are immutable.
+      # Static and stdlib-only, same as the coverage-honesty guard: a cd.yml parse plus three file
+      # reads, no cargo, no network.
+      - name: Guard publish-order scripts against cd.yml
+        run: bash ./scripts/ci-guard-publish-order.sh
+
       # Static (it never runs tarpaulin) and deliberately in core-validation rather than a coverage
       # job: it must run on EVERY PR, including the ones that never trigger a tarpaulin run. The
       # gaps it catches (a test-name filter shrinking the numerator, a package silently skipped,

--- a/docs/crates-io-publish.md
+++ b/docs/crates-io-publish.md
@@ -4,7 +4,7 @@ Internal `path` dependencies must include a **version** (same as `[workspace.pac
 
 **First-time or clean-machine dry-run** may still report `no matching package named 'lib-q-…' on crates.io` until upstream workspace crates are published in order. Follow `.github/workflows/cd.yml`: `lib-q-types` → tier 0 (`lib-q-core`, `lib-q-keccak`) → `lib-q-sha3` → tier 1 (including `lib-q-keccak-digest` after `lib-q-sha3`).
 
-**FN-DSA nested crates** publish as `lib-q-fn-dsa-comm`, `lib-q-fn-dsa-kgen`, `lib-q-fn-dsa-sign`, `lib-q-fn-dsa-vrfy`, and `lib-q-fn-dsa-alg` (not `fn-dsa-*`; those names belong to [pornin/rust-fn-dsa](https://github.com/pornin/rust-fn-dsa) on crates.io). Use `scripts/publish-crates-io-ordered.ps1` for the full ordered list.
+**FN-DSA nested crates** publish as `lib-q-fn-dsa-comm`, `lib-q-fn-dsa-kgen`, `lib-q-fn-dsa-sign`, `lib-q-fn-dsa-vrfy`, and `lib-q-fn-dsa-alg` (not `fn-dsa-*`; those names belong to [pornin/rust-fn-dsa](https://github.com/pornin/rust-fn-dsa) on crates.io). Use `scripts/publish-crates-io-ordered.ps1` for the full ordered list — it restates `cd.yml`, and `scripts/ci-guard-publish-order.sh` fails CI if the two ever disagree (at 0.0.10 the script listed 65 of `cd.yml`'s 80 crates and skipped the other 15 without erroring). Regenerate it with `python3 scripts/cd_publish_manifest.py --format crates`.
 
 **`lib-q-stark-baby-bear` (tier 10)**: the BabyBear prime field (`p = 2^31 - 2^27 + 1`) implemented as a `lib-q-stark-monty31` instance; it is the base field for the Arm B membership STARK. Its dependencies — `lib-q-stark-field` (tier 6) and `lib-q-stark-monty31` (tier 9) — are already published by the time tier 10 runs, and its dependents — `lib-q-poseidon` (tier 11) and `lib-q-zkp` (tier 16) — come later, so tier 10 is the correct slot. It is published alongside `lib-q-stark-challenger` and `lib-q-stark-interpolation` in the `publish-rust-tier-10` matrix.
 
@@ -16,7 +16,13 @@ Internal `path` dependencies must include a **version** (same as `[workspace.pac
 
 **Bump:** When the workspace version changes, update every internal `version = "…"` on path dependencies to match, or re-run the script with `WS_VERSION` updated.
 
-**Not every workspace member is in `cd.yml`.** Research, fuzz-only, or internal crates (for example `lib-q-lattice-zkp`, `lib-q-ring-sig`, `lib-q-prf`, `lib-q-sca-test`, `lib-q-ring`) stay path-only until explicitly added to a publish tier; see [CI_CD_SETUP.md](../CI_CD_SETUP.md) and the root `Cargo.toml` `[workspace].members` list.
+**Not every workspace member is in `cd.yml`.** A member stays path-only until it is added to a publish tier. As of 0.0.10 the only members `cd.yml` does not publish are the ones that carry `publish = false` in their own `[package]` (a withdrawn crate, and `examples/`) — the research and internal crates this note used to list as path-only (`lib-q-lattice-zkp`, `lib-q-ring-sig`, `lib-q-prf`, `lib-q-sca-test`, `lib-q-ring`) have all since been added to tiers and do publish. Do not read a crate's publish status off this paragraph; derive it:
+
+```bash
+python3 scripts/cd_publish_manifest.py --format crates    # what cd.yml publishes, in CD order
+```
+
+`scripts/ci-guard-new-crates-and-npm.sh` fails CI when a publishable workspace member is missing from `cd.yml`; see also [CI_CD_SETUP.md](../CI_CD_SETUP.md) and the root `Cargo.toml` `[workspace].members` list.
 
 **crates.io-only crates (no npm parity).** A few crates publish to crates.io but ship **no npm / WASM package**, and are exempt from the npm-parity CI guards in `scripts/ci-guard-new-crates-and-npm.sh`:
 

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -43,7 +43,7 @@ The script skips packages that are already published at the target version (npm 
 | `@lib-q/hash` | `lib-q-hash` | `pkg-hash` |
 | `@lib-q/utils` | `lib-q-utils` | `pkg-utils` |
 | `@lib-q/fn-dsa` | `lib-q-fn-dsa` | |
-| `@lib-q/aead` | `lib-q-aead` | |
+| `@lib-q/aead` | `lib-q-aead` | `wasm,saturnin,romulus,rocca-s,duplex-sponge-aead` |
 | `@lib-q/hpke` | `lib-q-hpke` | |
 | `@lib-q/zkp` | `lib-q-zkp` | |
 | `@lib-q/random` | `lib-q-random` | |
@@ -58,8 +58,18 @@ The script skips packages that are already published at the target version (npm 
 | `@lib-q/poseidon` | `lib-q-poseidon` | `wasm`, `alloc` |
 | `@lib-q/lattice-zkp` | `lib-q-lattice-zkp` | `wasm`, `random` |
 | `@lib-q/ring` | `lib-q-ring` | `wasm`, `alloc` |
+| `@lib-q/mac` | `lib-q-mac` | `wasm`, `random` |
+| `@lib-q/blind-pcs` | `lib-q-blind-pcs` | `wasm`, `blind-pcs`; EXPERIMENTAL_NON_NIST |
+| `@lib-q/double-kem` | `lib-q-double-kem` | `wasm`, `std`, `random`; PROVISIONAL |
+| `@lib-q/fhe` | `lib-q-fhe` | `wasm`, `fhe`; EXPERIMENTAL_NON_NIST |
+| `@lib-q/threshold-kem` | `lib-q-threshold-kem` | `wasm`, `std`, `random`; PROVISIONAL |
+| `@lib-q/dkg` | `lib-q-dkg` | `wasm`, `std`, `random`; PROVISIONAL |
+| `@lib-q/threshold-raccoon` | `lib-q-threshold-raccoon` | `wasm`, `std`, `random`; PROVISIONAL |
+| `@lib-q/threshold-kem-lattice` | `lib-q-threshold-kem-lattice` | `wasm`, `std`, `random`; PROVISIONAL |
 
-**Total: 22 packages** (indices 0–21 in `publish-npm-ordered.sh`). See [npm-coverage.md](npm-coverage.md).
+**Total: 30 packages** (indices 0–29 in `publish-npm-ordered.sh`). See [npm-coverage.md](npm-coverage.md).
+
+This table is checked against `cd.yml` on every pull request by [`scripts/ci-guard-publish-order.sh`](../scripts/ci-guard-publish-order.sh) — it claimed 22 packages against `cd.yml`'s 30 at 0.0.10. Regenerate with `python3 scripts/cd_publish_manifest.py --format npm` rather than editing by hand.
 
 Dual-target layout (`pkg/web` + `pkg/nodejs`) and `integrity-manifest.json` are applied by [`scripts/npm-publish-annotate.mjs`](../scripts/npm-publish-annotate.mjs), same as [`.github/actions/npm-publish`](../.github/actions/npm-publish/action.yml).
 

--- a/scripts/cd_publish_manifest.py
+++ b/scripts/cd_publish_manifest.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Derive the publish manifest (what ships, and in what order) from .github/workflows/cd.yml.
+
+WHY THIS EXISTS
+---------------
+`.github/workflows/cd.yml` is the ONLY authority on which crates and npm packages libQ
+publishes and in what order. Three other places restate that list by hand:
+
+  * scripts/publish-crates-io-ordered.ps1  -- the operator's crates.io fallback
+  * scripts/publish-npm-ordered.sh         -- the operator's npm fallback
+  * docs/npm-publish.md                    -- the "Package list (CD order)" table
+
+A hand-maintained restatement of a list that grows every release does not stay correct: at
+0.0.10 the PowerShell fallback listed 65 of cd.yml's 80 crates. Nothing failed. An operator
+who fell back to it would have shipped an incomplete release and been told "All 65 workspace
+crates published." crates.io versions are immutable, so that ships wrong permanently.
+
+This module is the single derivation point. scripts/ci_guard_publish_order.py diffs every
+restatement against it on each pull request, and scripts/publish-readiness-pr.sh uses it
+instead of its own regex over cd.yml.
+
+WHY IT SHIPS ITS OWN YAML PARSER
+--------------------------------
+It runs in the ci.yml `core-validation` job, which has no pip step (same constraint as
+scripts/ci_guard_coverage_honesty.py), and PyYAML is not a dependency of this repo -- no
+script imports it today. So the parser below is stdlib-only and covers exactly the block-YAML
+subset cd.yml uses. It FAILS CLOSED: anything it does not model (tabs, anchors/aliases, flow
+mappings, merge keys) raises rather than being silently skipped, because a parser that
+silently drops a job is the very failure mode this file exists to prevent.
+
+It is also cross-checked: `--self-check` re-derives the manifest with PyYAML when PyYAML
+happens to be importable (dev boxes) and errors if the two disagree. CI does not depend on
+that, but a divergence introduced by a future cd.yml construct gets caught by anyone who runs
+the guard locally.
+
+WHAT THIS DOES *NOT* MODEL
+--------------------------
+  * `if:` conditions on publish jobs -- every crate-publish/npm-publish step is treated as
+    unconditional. cd.yml has no conditional publish job today; one added later would be
+    reported as always-publishing.
+  * matrix `exclude:` / non-`include` matrix axes -- only `strategy.matrix.include` is
+    expanded. A cartesian matrix over a `package:` axis would raise rather than be guessed at.
+  * Ordering WITHIN a matrix job. cd.yml matrix entries run in parallel, so cd.yml asserts no
+    order between them; only the `needs` DAG constrains order (see `ancestor_map`).
+
+Usage:
+  python3 scripts/cd_publish_manifest.py [--root DIR] --format {json,crates,npm}
+  python3 scripts/cd_publish_manifest.py --self-check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+CRATE_PUBLISH_ACTION = "./.github/actions/crate-publish"
+NPM_PUBLISH_ACTION = "./.github/actions/npm-publish"
+
+_MATRIX_REF = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_-]+)")
+_BLOCK_SCALAR = re.compile(r"^[|>][+-]?[0-9]*$")
+_KEY_LINE = re.compile(r'^(?:"([^"]*)"|\'([^\']*)\'|([^:]+?))\s*:(?:\s+(.*?))?\s*$')
+
+
+class CdParseError(RuntimeError):
+    """cd.yml contains a construct this parser does not model. Always fatal."""
+
+
+# ---------------------------------------------------------------------------
+# Minimal block-YAML parser (stdlib only, fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def _leading_indent(line: str) -> int:
+    stripped = line.lstrip(" ")
+    n = len(line) - len(stripped)
+    if "\t" in line[:n]:
+        raise CdParseError(f"tab in indentation: {line!r}")
+    return n
+
+
+def _strip_comment(line: str) -> str:
+    """Drop a trailing `# ...` comment, honouring quoted scalars."""
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if quote is not None:
+            out.append(ch)
+            if ch == "\\" and quote == '"' and i + 1 < len(line):
+                i += 1
+                out.append(line[i])
+            elif ch == quote:
+                quote = None
+        elif ch in "\"'":
+            quote = ch
+            out.append(ch)
+        elif ch == "#" and (not out or out[-1] in " \t"):
+            break
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out).rstrip()
+
+
+def _is_blank(line: str) -> bool:
+    return _strip_comment(line).strip() == ""
+
+
+def _next_significant(lines: list[str], i: int) -> int:
+    while i < len(lines) and _is_blank(lines[i]):
+        i += 1
+    return i
+
+
+def _scalar(raw: str) -> object:
+    text = raw.strip()
+    if text == "" or text == "~" or text == "null":
+        return None
+    if text[0] in "&*":
+        raise CdParseError(f"YAML anchors/aliases are not modelled: {raw!r}")
+    if text[0] == "{":
+        raise CdParseError(f"flow mappings are not modelled: {raw!r}")
+    if text[0] == "[":
+        if not text.endswith("]"):
+            raise CdParseError(f"multi-line flow sequence is not modelled: {raw!r}")
+        return _flow_sequence(text[1:-1])
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        body = text[1:-1]
+        if text[0] == '"':
+            body = body.replace('\\"', '"').replace("\\\\", "\\")
+        return body
+    return text
+
+
+def _flow_sequence(body: str) -> list[object]:
+    items: list[str] = []
+    depth = 0
+    quote: str | None = None
+    current: list[str] = []
+    for ch in body:
+        if quote is not None:
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+            current.append(ch)
+        elif ch in "[{":
+            depth += 1
+            current.append(ch)
+        elif ch in "]}":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            items.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    if "".join(current).strip():
+        items.append("".join(current))
+    return [_scalar(item) for item in items]
+
+
+def _consume_block_scalar(lines: list[str], i: int, key_indent: int) -> tuple[str, int]:
+    body: list[str] = []
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "":
+            body.append("")
+            i += 1
+            continue
+        if _leading_indent(line) <= key_indent:
+            break
+        body.append(line)
+        i += 1
+    return "\n".join(body), i
+
+
+def _parse_node(lines: list[str], i: int, indent: int) -> tuple[object, int]:
+    i = _next_significant(lines, i)
+    if i >= len(lines) or _leading_indent(lines[i]) < indent:
+        return None, i
+    content = _strip_comment(lines[i]).strip()
+    if content == "-" or content.startswith("- "):
+        return _parse_sequence(lines, i, indent)
+    return _parse_mapping(lines, i, indent)
+
+
+def _parse_mapping(lines: list[str], i: int, indent: int) -> tuple[dict, int]:
+    result: dict[str, object] = {}
+    while True:
+        i = _next_significant(lines, i)
+        if i >= len(lines):
+            return result, i
+        line_indent = _leading_indent(lines[i])
+        if line_indent < indent:
+            return result, i
+        if line_indent > indent:
+            raise CdParseError(f"unexpected indent at line {i + 1}: {lines[i]!r}")
+        content = _strip_comment(lines[i]).strip()
+        if content.startswith("- "):
+            return result, i
+        if content.startswith("<<"):
+            raise CdParseError(f"merge keys are not modelled: {lines[i]!r}")
+        m = _KEY_LINE.match(content)
+        if not m:
+            raise CdParseError(f"unparsable mapping line {i + 1}: {lines[i]!r}")
+        key = next(g for g in m.groups()[:3] if g is not None).strip()
+        raw_value = m.group(4)
+        i += 1
+        if raw_value and _BLOCK_SCALAR.match(raw_value):
+            value, i = _consume_block_scalar(lines, i, line_indent)
+        elif raw_value:
+            value = _scalar(raw_value)
+        else:
+            j = _next_significant(lines, i)
+            if j < len(lines) and _leading_indent(lines[j]) > line_indent:
+                value, i = _parse_node(lines, j, _leading_indent(lines[j]))
+            else:
+                value = None
+        if key in result:
+            raise CdParseError(f"duplicate key {key!r} at line {i}")
+        result[key] = value
+
+
+def _parse_sequence(lines: list[str], i: int, indent: int) -> tuple[list, int]:
+    items: list[object] = []
+    work = lines  # mutated in place for the "- key: value" continuation trick
+    while True:
+        i = _next_significant(work, i)
+        if i >= len(work):
+            return items, i
+        line_indent = _leading_indent(work[i])
+        if line_indent < indent:
+            return items, i
+        content = _strip_comment(work[i]).strip()
+        if not (content == "-" or content.startswith("- ")):
+            return items, i
+        if line_indent != indent:
+            raise CdParseError(f"ragged sequence indent at line {i + 1}: {work[i]!r}")
+        stripped = _strip_comment(work[i])
+        dash_col = len(stripped) - len(stripped.lstrip(" "))
+        rest = stripped[dash_col + 1 :]
+        if rest.strip() == "":
+            i += 1
+            j = _next_significant(work, i)
+            if j < len(work) and _leading_indent(work[j]) > indent:
+                value, i = _parse_node(work, j, _leading_indent(work[j]))
+            else:
+                value = None
+            items.append(value)
+            continue
+        item_col = dash_col + 1 + (len(rest) - len(rest.lstrip(" ")))
+        payload = " " * item_col + rest.lstrip(" ")
+        if _KEY_LINE.match(payload.strip()):
+            work[i] = payload
+            value, i = _parse_mapping(work, i, item_col)
+        else:
+            value = _scalar(rest)
+            i += 1
+        items.append(value)
+
+
+def parse_yaml(text: str) -> object:
+    lines = text.replace("\r\n", "\n").split("\n")
+    lines = [line for line in lines if line.strip() != "---"]
+    value, _ = _parse_node(lines, 0, 0)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Publish-manifest extraction
+# ---------------------------------------------------------------------------
+
+
+def _needs_of(jobs: dict, name: str) -> list[str]:
+    needs = jobs[name].get("needs") or []
+    if isinstance(needs, str):
+        needs = [needs]
+    for dep in needs:
+        if dep not in jobs:
+            raise CdParseError(f"job {name!r} needs unknown job {dep!r}")
+    return list(needs)
+
+
+def job_order(jobs: dict) -> list[str]:
+    """Deterministic topological order: earliest ready job in file order wins."""
+    remaining = list(jobs)
+    done: set[str] = set()
+    order: list[str] = []
+    while remaining:
+        for name in remaining:
+            if all(dep in done for dep in _needs_of(jobs, name)):
+                order.append(name)
+                done.add(name)
+                remaining.remove(name)
+                break
+        else:
+            raise CdParseError(f"cycle in cd.yml job `needs`: {remaining}")
+    return order
+
+
+def ancestor_map(jobs: dict) -> dict[str, set[str]]:
+    """job -> every job that must complete before it (transitive `needs` closure)."""
+    cache: dict[str, set[str]] = {}
+
+    def walk(name: str, seen: frozenset) -> set[str]:
+        if name in cache:
+            return cache[name]
+        if name in seen:
+            raise CdParseError(f"cycle in cd.yml job `needs` at {name!r}")
+        acc: set[str] = set()
+        for dep in _needs_of(jobs, name):
+            acc.add(dep)
+            acc |= walk(dep, seen | {name})
+        cache[name] = acc
+        return acc
+
+    return {name: walk(name, frozenset()) for name in jobs}
+
+
+def _matrix_include(job: dict, job_name: str) -> list[dict]:
+    strategy = job.get("strategy") or {}
+    matrix = strategy.get("matrix") or {}
+    if not isinstance(matrix, dict):
+        raise CdParseError(f"job {job_name!r}: unmodelled matrix shape")
+    extra = set(matrix) - {"include", "fail-fast"}
+    if extra:
+        raise CdParseError(
+            f"job {job_name!r}: only `strategy.matrix.include` is modelled, found axes {sorted(extra)}"
+        )
+    include = matrix.get("include") or []
+    if not isinstance(include, list):
+        raise CdParseError(f"job {job_name!r}: `matrix.include` is not a list")
+    return include
+
+
+def _resolve(value, entry: dict, job_name: str, field: str):
+    """Resolve a `with:` value that may reference `matrix.<field>`."""
+    if not isinstance(value, str):
+        return value
+    ref = _MATRIX_REF.search(value)
+    if not ref:
+        return value
+    name = ref.group(1)
+    if value.strip() != "${{ matrix.%s }}" % name:
+        # e.g. `${{ matrix.out-dir || 'pkg' }}` -- honour the documented default only.
+        fallback = re.search(r"\|\|\s*'([^']*)'\s*\}\}", value)
+        resolved = entry.get(name)
+        if resolved not in (None, ""):
+            return resolved
+        if fallback:
+            return fallback.group(1)
+        raise CdParseError(
+            f"job {job_name!r}: cannot resolve {field}={value!r} for matrix entry {entry!r}"
+        )
+    if name not in entry:
+        raise CdParseError(
+            f"job {job_name!r}: matrix entry {entry!r} has no `{name}` for {field}"
+        )
+    return entry[name]
+
+
+def extract(root: pathlib.Path, doc: dict | None = None) -> dict:
+    """Return {"crates": [...], "npm": [...], "jobs": [...], "ancestors": {...}}."""
+    if doc is None:
+        cd_path = root / ".github" / "workflows" / "cd.yml"
+        if not cd_path.is_file():
+            raise CdParseError(f"missing {cd_path}")
+        doc = parse_yaml(cd_path.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict):
+        raise CdParseError("cd.yml did not parse to a mapping")
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict) or not jobs:
+        raise CdParseError("cd.yml has no `jobs:` mapping")
+
+    order = job_order(jobs)
+    ancestors = ancestor_map(jobs)
+    crates: list[dict] = []
+    npm: list[dict] = []
+
+    for job_name in order:
+        job = jobs[job_name]
+        steps = job.get("steps") or []
+        if not isinstance(steps, list):
+            raise CdParseError(f"job {job_name!r}: `steps` is not a list")
+        include = None
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if uses not in (CRATE_PUBLISH_ACTION, NPM_PUBLISH_ACTION):
+                continue
+            with_ = step.get("with") or {}
+            if not isinstance(with_, dict):
+                raise CdParseError(f"job {job_name!r}: publish step has no `with:` mapping")
+            key = "package" if uses == CRATE_PUBLISH_ACTION else "package-name"
+            raw = with_.get(key)
+            if not isinstance(raw, str) or not raw:
+                raise CdParseError(f"job {job_name!r}: publish step is missing `{key}`")
+            if _MATRIX_REF.search(raw):
+                if include is None:
+                    include = _matrix_include(job, job_name)
+                if not include:
+                    raise CdParseError(
+                        f"job {job_name!r}: publish step reads `matrix.*` but the job has no matrix.include"
+                    )
+                entries = include
+            else:
+                entries = [{}]
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    raise CdParseError(f"job {job_name!r}: matrix entry is not a mapping")
+                if uses == CRATE_PUBLISH_ACTION:
+                    crates.append(
+                        {
+                            "package": _resolve(raw, entry, job_name, key),
+                            "working_directory": _resolve(
+                                with_.get("working-directory"), entry, job_name, "working-directory"
+                            ),
+                            "job": job_name,
+                        }
+                    )
+                else:
+                    # The npm-publish step's own `working-directory` is the *built package*
+                    # dir (`${{ format('{0}/{1}', matrix.working-directory, ...) }}`); the
+                    # crate root that the wasm build runs in is the matrix entry's
+                    # `working-directory`. Take the crate root -- that is what the fallback
+                    # script and the docs table restate.
+                    npm.append(
+                        {
+                            "package": _resolve(raw, entry, job_name, key),
+                            "working_directory": entry.get("working-directory")
+                            if entry
+                            else with_.get("working-directory"),
+                            "features": entry.get("features") if entry else None,
+                            "out_dir": entry.get("out-dir") if entry else None,
+                            "job": job_name,
+                        }
+                    )
+
+    if not crates:
+        raise CdParseError("cd.yml yielded zero crate-publish steps -- refusing to report success")
+    if not npm:
+        raise CdParseError("cd.yml yielded zero npm-publish steps -- refusing to report success")
+
+    for item in crates + npm:
+        for field in ("package", "working_directory"):
+            value = item.get(field)
+            if isinstance(value, str) and "${{" in value:
+                raise CdParseError(f"unresolved {field}={value!r} for {item['package']!r}")
+    for item in npm:
+        if not item["working_directory"]:
+            raise CdParseError(f"npm package {item['package']!r} has no working-directory")
+        # cd.yml defaults out-dir to `pkg` (`${{ matrix.out-dir || 'pkg' }}`); the TypeScript-only
+        # package is published straight from its source dir and has no wasm-pack out-dir at all.
+        if item["out_dir"] in (None, "") and item["job"] != "publish-npm-types":
+            item["out_dir"] = "pkg"
+
+    seen: set[str] = set()
+    for item in crates:
+        if item["package"] in seen:
+            raise CdParseError(f"cd.yml publishes {item['package']!r} twice")
+        seen.add(item["package"])
+
+    return {"crates": crates, "npm": npm, "jobs": order, "ancestors": {k: sorted(v) for k, v in ancestors.items()}}
+
+
+def crate_names(root: pathlib.Path) -> list[str]:
+    return [c["package"] for c in extract(root)["crates"]]
+
+
+# ---------------------------------------------------------------------------
+# Self-check against PyYAML (only when PyYAML is importable)
+# ---------------------------------------------------------------------------
+
+
+def self_check(root: pathlib.Path) -> int:
+    mine = extract(root)
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        print("self-check: PyYAML not importable; stdlib parser not cross-validated (OK)")
+        return 0
+    cd_path = root / ".github" / "workflows" / "cd.yml"
+    theirs = extract(root, doc=yaml.safe_load(cd_path.read_text(encoding="utf-8")))
+    diffs = []
+    for field in ("crates", "npm", "jobs"):
+        if mine[field] != theirs[field]:
+            diffs.append(field)
+    if diffs:
+        print(f"self-check FAILED: stdlib parser disagrees with PyYAML on {diffs}", file=sys.stderr)
+        for field in diffs:
+            print(f"  stdlib: {json.dumps(mine[field], indent=2)}", file=sys.stderr)
+            print(f"  pyyaml: {json.dumps(theirs[field], indent=2)}", file=sys.stderr)
+        return 1
+    print(
+        f"self-check: stdlib parser == PyYAML "
+        f"({len(mine['crates'])} crates, {len(mine['npm'])} npm packages, {len(mine['jobs'])} jobs)"
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", default=None, help="repo root (default: this file's parent's parent)")
+    ap.add_argument("--format", choices=("json", "crates", "npm", "jobs"), default="json")
+    ap.add_argument("--self-check", action="store_true", help="cross-validate against PyYAML if present")
+    args = ap.parse_args(argv)
+
+    root = pathlib.Path(args.root) if args.root else pathlib.Path(__file__).resolve().parent.parent
+    if args.self_check:
+        return self_check(root)
+
+    manifest = extract(root)
+    if args.format == "json":
+        print(json.dumps(manifest, indent=2))
+    elif args.format == "crates":
+        for item in manifest["crates"]:
+            print(item["package"])
+    elif args.format == "npm":
+        for item in manifest["npm"]:
+            print(
+                "\t".join(
+                    [
+                        item["package"],
+                        item["working_directory"] or "",
+                        item["features"] or "",
+                        item["out_dir"] or "",
+                    ]
+                )
+            )
+    else:
+        for name in manifest["jobs"]:
+            print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/cd_publish_manifest.py
+++ b/scripts/cd_publish_manifest.py
@@ -76,7 +76,13 @@ class CdParseError(RuntimeError):
 def _leading_indent(line: str) -> int:
     stripped = line.lstrip(" ")
     n = len(line) - len(stripped)
-    if "\t" in line[:n]:
+    # `stripped` is whatever follows the leading spaces `lstrip(" ")` consumed, so if a tab sits
+    # in that indentation, `lstrip(" ")` stops there and `stripped` starts with it -- that is the
+    # reachable form of this check. (The previous form tested `"\t" in line[:n]`, i.e. the spaces
+    # already counted off by `n`, which by construction can never contain a tab: dead code that
+    # never fired. Parsing a tab-indented cd.yml still failed before this fix, just via the
+    # generic "unexpected indent" error further down the parser, not this tab-specific message.)
+    if stripped.startswith("\t"):
         raise CdParseError(f"tab in indentation: {line!r}")
     return n
 

--- a/scripts/ci-guard-publish-order.sh
+++ b/scripts/ci-guard-publish-order.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Guard: every restatement of "what libQ publishes" must still match cd.yml.
+#
+# WHY THIS EXISTS
+# ---------------
+# `.github/workflows/cd.yml` is the authority on which crates and npm packages ship and in what
+# order. Three places restate that list by hand, and a restatement of a list that grows every
+# release does not stay correct on its own:
+#
+#   * scripts/publish-crates-io-ordered.ps1 -- the crates.io fallback an operator reaches for when
+#     the tag-triggered CD path is unavailable. At 0.0.10 its header claimed to mirror cd.yml while
+#     listing 65 of cd.yml's 80 crates. The 15 it omitted (lib-q-rocca-s, lib-q-mayo, lib-q-mac,
+#     lib-q-threshold-kem, lib-q-double-kem, lib-q-fhe, lib-q-blind-pcs, lib-q-dkg,
+#     lib-q-blind-token, lib-q-threshold-raccoon, lib-q-threshold-kem-lattice,
+#     lib-q-stark-baby-bear, lib-q-mve, lib-q-transcript, lib-q-zk-encryption-proof) would not
+#     error -- they would simply never publish, under a closing banner that says the run succeeded.
+#     crates.io versions are immutable, so an incomplete release is permanent.
+#   * scripts/publish-npm-ordered.sh -- same failure mode on the npm side, and it can also drift on
+#     BUILD PARAMETERS rather than membership: at 0.0.10 it built @lib-q/aead without the `rocca-s`
+#     feature cd.yml builds it with, which ships a package that silently lacks a cipher.
+#   * docs/npm-publish.md "Package list (CD order)" -- the table an operator reads to decide what
+#     a release should contain. At 0.0.10 it claimed "Total: 22 packages" against cd.yml's 30.
+#
+# None of those is a compile error, a test failure, or a runtime fault. They are a config that
+# quietly stopped matching reality -- the same shape as the coverage gate that kept scoring a
+# crate after its test filter was narrowed (scripts/ci-guard-coverage-honesty.sh). So the fix is
+# the same shape too: derive the truth from the authority, diff every restatement against it, and
+# fail the pull request that introduces the divergence.
+#
+# The derivation lives in scripts/cd_publish_manifest.py (stdlib-only block-YAML parser, because
+# ci.yml's core-validation job has no pip step and PyYAML is not a dependency of this repo). The
+# checks live in scripts/ci_guard_publish_order.py.
+#
+# WHAT THIS GUARD DOES *NOT* COVER
+# --------------------------------
+#   * It is STATIC. It never publishes anything, and it cannot tell you that cd.yml's own order is
+#     correct -- only that the fallback scripts do not contradict it.
+#   * It does not check that a crate CAN be published (version pins, forward dev-deps, feature
+#     resolution). scripts/publish-readiness-pr.sh and the CD tiers do that.
+#   * It does not model `if:` conditions on publish jobs, matrix `exclude:`, or non-`include`
+#     matrix axes; cd_publish_manifest.py raises on those rather than guessing.
+#   * Ordering inside one cd.yml matrix job is deliberately unconstrained -- those entries publish
+#     in parallel, so cd.yml asserts nothing about their relative order (see CHECK 2's rationale).
+#
+# Usage: bash scripts/ci-guard-publish-order.sh [REPO_ROOT]
+
+set -euo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+cd "$ROOT"
+
+# Probe by RUNNING each candidate: on Windows a `python3` App Execution Alias sits on PATH and
+# satisfies `command -v` while refusing to execute.
+PY_BIN=""
+for candidate in python3 python py; do
+  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="$candidate"
+    break
+  fi
+done
+if [[ -z "$PY_BIN" ]]; then
+  echo "ci-guard-publish-order: a working python3 interpreter is required" >&2
+  exit 1
+fi
+
+# Cross-validates the stdlib block-YAML parser against PyYAML when PyYAML happens to be importable
+# (dev boxes); a no-op that prints and returns 0 where it is not (CI runners without it).
+"$PY_BIN" scripts/cd_publish_manifest.py --root "$ROOT" --self-check
+"$PY_BIN" scripts/ci_guard_publish_order.py "$ROOT"

--- a/scripts/ci_guard_publish_order.py
+++ b/scripts/ci_guard_publish_order.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Assert that every hand-maintained restatement of the publish list still matches cd.yml.
+
+Driven by scripts/ci-guard-publish-order.sh (see that file for the rationale).
+Standard library only: this runs in the ci.yml `core-validation` job, which has no pip step.
+
+  CHECK 1  scripts/publish-crates-io-ordered.ps1 `$packages` publishes exactly cd.yml's crates
+  CHECK 2  ...in an order that respects cd.yml's `needs` DAG
+  CHECK 3  scripts/publish-crates-io-ordered.ps1 `$nestedManifest` matches cd.yml's
+           `working-directory:` overrides (the nested FN-DSA manifests)
+  CHECK 4  scripts/publish-npm-ordered.sh publishes exactly cd.yml's npm packages, with the
+           same crate dir, wasm-pack features and out-dir
+  CHECK 5  the docs/npm-publish.md "Package list (CD order)" table lists exactly those packages
+           and states the right total
+
+Every check fails CLOSED: if a list cannot be located or parsed, that is an error, not a pass.
+A guard that silently finds nothing to compare is indistinguishable from a guard that passes.
+
+WHY ORDER IS CHECKED AS A DAG, NOT AS A SEQUENCE (CHECK 2)
+----------------------------------------------------------
+cd.yml runs matrix entries in PARALLEL, so it asserts no order between crates inside one job --
+only `needs` between jobs constrains anything. Demanding that the fallback script reproduce one
+particular linearization would encode an arbitrary choice as gospel and would forbid legitimate
+local-only reordering (e.g. publishing lib-q-blind-pcs before lib-q-fhe, which shares its tier-4b
+matrix but is a dev-dependency of it). So the rule is: for every pair where cd.yml makes job(A) a
+transitive prerequisite of job(B), the script must publish A before B.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from cd_publish_manifest import CdParseError, extract  # noqa: E402
+
+PS1 = "scripts/publish-crates-io-ordered.ps1"
+NPM_SH = "scripts/publish-npm-ordered.sh"
+NPM_DOC = "docs/npm-publish.md"
+
+failures: list[str] = []
+
+
+def fail(check: str, message: str) -> None:
+    failures.append(f"[{check}] {message}")
+
+
+def read(root: pathlib.Path, rel: str) -> str:
+    path = root / rel
+    if not path.is_file():
+        raise SystemExit(f"ci-guard-publish-order: expected file is missing: {rel}")
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Restatement parsers -- each raises (never returns empty) when it finds nothing
+# ---------------------------------------------------------------------------
+
+
+def ps1_packages(text: str) -> list[str]:
+    m = re.search(r"^\$packages\s*=\s*@\(\s*$(.*?)^\)\s*$", text, re.MULTILINE | re.DOTALL)
+    if not m:
+        raise SystemExit(f"ci-guard-publish-order: could not locate `$packages = @(...)` in {PS1}")
+    names = re.findall(r'"([^"]+)"', m.group(1))
+    if not names:
+        raise SystemExit(f"ci-guard-publish-order: `$packages` in {PS1} parsed to zero entries")
+    return names
+
+
+def ps1_nested_manifests(text: str) -> dict[str, str]:
+    m = re.search(r"^\$nestedManifest\s*=\s*@\{\s*$(.*?)^\}\s*$", text, re.MULTILINE | re.DOTALL)
+    if not m:
+        raise SystemExit(f"ci-guard-publish-order: could not locate `$nestedManifest = @{{...}}` in {PS1}")
+    pairs = re.findall(r'"([^"]+)"\s*=\s*"([^"]+)"', m.group(1))
+    return dict(pairs)
+
+
+def sh_npm_rows(text: str) -> list[dict[str, str]]:
+    m = re.search(r"<<'EOF'.*?\n(.*?)\nEOF\n", text, re.DOTALL)
+    if not m:
+        raise SystemExit(f"ci-guard-publish-order: could not locate the PACKAGES heredoc in {NPM_SH}")
+    rows = []
+    for line in m.group(1).splitlines():
+        if not line.strip() or "|" not in line:
+            continue
+        parts = (line.split("|") + [""] * 7)[:7]
+        rows.append(
+            {
+                "working_directory": parts[0],
+                "package": parts[1],
+                "features": parts[4],
+                "out_dir": parts[5],
+                "types_only": parts[6],
+            }
+        )
+    if not rows:
+        raise SystemExit(f"ci-guard-publish-order: the PACKAGES heredoc in {NPM_SH} parsed to zero rows")
+    return rows
+
+
+def doc_npm_table(text: str) -> tuple[list[str], int | None]:
+    m = re.search(r"^## Package list \(CD order\)\s*$(.*?)^## ", text, re.MULTILINE | re.DOTALL)
+    if not m:
+        raise SystemExit(
+            f"ci-guard-publish-order: could not locate the '## Package list (CD order)' section in {NPM_DOC}"
+        )
+    section = m.group(1)
+    names = re.findall(r"^\|\s*`(@lib-q/[^`]+)`\s*\|", section, re.MULTILINE)
+    if not names:
+        raise SystemExit(f"ci-guard-publish-order: the {NPM_DOC} package table parsed to zero rows")
+    total = re.search(r"\*\*Total:\s*(\d+)\s+packages\*\*", section)
+    return names, int(total.group(1)) if total else None
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def check_crate_membership(cd_crates: list[str], script: list[str]) -> None:
+    missing = [c for c in cd_crates if c not in script]
+    extra = [c for c in script if c not in cd_crates]
+    if missing:
+        fail(
+            "CHECK 1",
+            f"{PS1} would silently skip {len(missing)} crate(s) that cd.yml publishes: "
+            + ", ".join(missing),
+        )
+    if extra:
+        fail(
+            "CHECK 1",
+            f"{PS1} lists {len(extra)} crate(s) cd.yml does not publish: " + ", ".join(extra),
+        )
+    dupes = sorted({c for c in script if script.count(c) > 1})
+    if dupes:
+        fail("CHECK 1", f"{PS1} lists these crates more than once: " + ", ".join(dupes))
+
+
+def check_crate_order(manifest: dict, script: list[str]) -> None:
+    job_of = {c["package"]: c["job"] for c in manifest["crates"]}
+    ancestors = {k: set(v) for k, v in manifest["ancestors"].items()}
+    position = {name: i for i, name in enumerate(script)}
+    reported = 0
+    for later, later_pos in position.items():
+        job_later = job_of.get(later)
+        if job_later is None:
+            continue
+        for earlier, earlier_pos in position.items():
+            job_earlier = job_of.get(earlier)
+            if job_earlier is None or earlier_pos <= later_pos:
+                continue
+            if job_earlier in ancestors.get(job_later, ()):
+                fail(
+                    "CHECK 2",
+                    f"{PS1} publishes {later} (#{later_pos}, cd.yml job {job_later}) before its "
+                    f"cd.yml prerequisite {earlier} (#{earlier_pos}, job {job_earlier})",
+                )
+                reported += 1
+                if reported >= 25:
+                    fail("CHECK 2", "... further order violations suppressed")
+                    return
+
+
+def check_nested_manifests(manifest: dict, nested: dict[str, str]) -> None:
+    expected = {
+        c["package"]: f"{c['working_directory']}/Cargo.toml"
+        for c in manifest["crates"]
+        if c["working_directory"]
+    }
+    for pkg, path in expected.items():
+        if pkg not in nested:
+            fail(
+                "CHECK 3",
+                f"{PS1} `$nestedManifest` is missing {pkg} -> {path}; cd.yml publishes that crate "
+                f"with an explicit `working-directory:`, so `cargo publish -p` from the repo root "
+                f"would resolve the wrong manifest",
+            )
+        elif nested[pkg].replace("\\", "/") != path:
+            fail("CHECK 3", f"{PS1} `$nestedManifest[{pkg}]` = {nested[pkg]!r}, cd.yml says {path!r}")
+    for pkg in nested:
+        if pkg not in expected:
+            fail("CHECK 3", f"{PS1} `$nestedManifest` has {pkg}, which cd.yml publishes from the repo root")
+
+
+def check_npm(manifest: dict, rows: list[dict[str, str]]) -> None:
+    cd_by_name = {item["package"]: item for item in manifest["npm"]}
+    sh_by_name = {row["package"]: row for row in rows}
+    for name in cd_by_name:
+        if name not in sh_by_name:
+            fail("CHECK 4", f"{NPM_SH} would silently skip {name}, which cd.yml publishes")
+    for name in sh_by_name:
+        if name not in cd_by_name:
+            fail("CHECK 4", f"{NPM_SH} lists {name}, which cd.yml does not publish")
+    for name, item in cd_by_name.items():
+        row = sh_by_name.get(name)
+        if row is None:
+            continue
+        if row["working_directory"] != item["working_directory"]:
+            fail(
+                "CHECK 4",
+                f"{NPM_SH} builds {name} from {row['working_directory']!r}; "
+                f"cd.yml uses {item['working_directory']!r}",
+            )
+        if row["types_only"] == "1":
+            # TypeScript-only package: no wasm-pack build, so features/out-dir do not apply.
+            continue
+        if row["features"] != (item["features"] or ""):
+            fail(
+                "CHECK 4",
+                f"{NPM_SH} builds {name} with features {row['features']!r}; "
+                f"cd.yml uses {(item['features'] or '')!r}",
+            )
+        if row["out_dir"] != (item["out_dir"] or ""):
+            fail(
+                "CHECK 4",
+                f"{NPM_SH} builds {name} into out-dir {row['out_dir']!r}; "
+                f"cd.yml uses {(item['out_dir'] or '')!r}",
+            )
+
+
+def check_doc(manifest: dict, names: list[str], total: int | None) -> None:
+    cd_names = [item["package"] for item in manifest["npm"]]
+    for name in cd_names:
+        if name not in names:
+            fail("CHECK 5", f"{NPM_DOC} package table is missing {name}, which cd.yml publishes")
+    for name in names:
+        if name not in cd_names:
+            fail("CHECK 5", f"{NPM_DOC} package table lists {name}, which cd.yml does not publish")
+    if total is None:
+        fail("CHECK 5", f"{NPM_DOC} no longer states a '**Total: N packages**' count")
+    elif total != len(cd_names):
+        fail("CHECK 5", f"{NPM_DOC} claims {total} packages; cd.yml publishes {len(cd_names)}")
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    try:
+        manifest = extract(root)
+    except CdParseError as exc:
+        print(f"ci-guard-publish-order: cannot derive the publish manifest from cd.yml: {exc}", file=sys.stderr)
+        return 1
+
+    cd_crates = [c["package"] for c in manifest["crates"]]
+    ps1_text = read(root, PS1)
+    script_crates = ps1_packages(ps1_text)
+
+    check_crate_membership(cd_crates, script_crates)
+    check_crate_order(manifest, script_crates)
+    check_nested_manifests(manifest, ps1_nested_manifests(ps1_text))
+    check_npm(manifest, sh_npm_rows(read(root, NPM_SH)))
+    doc_names, doc_total = doc_npm_table(read(root, NPM_DOC))
+    check_doc(manifest, doc_names, doc_total)
+
+    if failures:
+        print("ERROR: a publish list has drifted from .github/workflows/cd.yml.", file=sys.stderr)
+        print(
+            "cd.yml is the authority. An out-of-date fallback script does not error -- it just "
+            "publishes fewer crates and reports success.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+        for item in failures:
+            print(f"  {item}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            "Regenerate the lists from cd.yml:\n"
+            "  python3 scripts/cd_publish_manifest.py --format crates\n"
+            "  python3 scripts/cd_publish_manifest.py --format npm",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"publish-order guard: OK ({len(cd_crates)} crates, {len(manifest['npm'])} npm packages "
+        f"in cd.yml; fallback scripts and docs/npm-publish.md agree)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_guard_publish_order.py
+++ b/scripts/ci_guard_publish_order.py
@@ -59,8 +59,84 @@ def read(root: pathlib.Path, rel: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _strip_ps1_comments(text: str, source: str) -> str:
+    """Blank out PowerShell `# ...` line comments and `<# ... #>` block comments,
+    leaving string literals -- and every other character -- exactly where they
+    were (comment text is replaced with spaces, newlines are kept), so the
+    `re.MULTILINE`/`re.DOTALL` anchors the callers use still line up.
+
+    This is deliberately NOT `line.split('#')[0]`. PowerShell, like most
+    languages, does not treat `#` as a comment when it is inside a string --
+    `"lib-q-mac # not a comment"` is one 26-character string, not a crate name
+    truncated at the space. A naive split-on-`#` would silently mis-parse that
+    (and, worse, would fail to notice a REAL comment hiding a crate, which is
+    the bug this function exists to fix). So this walks the text one character
+    at a time and tracks whether it is inside a single-quoted string (`'...'`,
+    self-escaped as `''`), a double-quoted string (`"..."`, escaped with a
+    backtick or self-escaped as `""`), or a block comment -- `#` only starts a
+    line comment, and `<#` only starts a block comment, when none of those
+    apply. A tokenizer that tracks this one bit of state (in-string or not) is
+    harder to get subtly wrong than any regex/strip trick operating on whole
+    lines, because it can never misjudge a `#` by looking at the wrong side of
+    a quote.
+
+    Fails closed on here-strings (`@"` / `@'`): every restatement this scanner
+    reads is a flat list of plain quoted scalars, so a here-string appearing
+    here means a construct this scanner was not built to reason about has been
+    introduced. Guessing at where it ends is exactly the kind of blind spot
+    this guard exists to close, so this raises instead.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        two = text[i : i + 2]
+        if two == "<#":
+            end = text.find("#>", i + 2)
+            if end == -1:
+                raise SystemExit(f"ci-guard-publish-order: unterminated <# comment #> in {source}")
+            out.append("".join(c if c == "\n" else " " for c in text[i : end + 2]))
+            i = end + 2
+            continue
+        if two in ('@"', "@'"):
+            raise SystemExit(
+                f"ci-guard-publish-order: here-string ({two}...) in {source} is not modelled by "
+                "this scanner -- rewrite the restatement using plain quoted entries"
+            )
+        ch = text[i]
+        if ch in "\"'":
+            quote = ch
+            j = i + 1
+            while j < n:
+                if quote == '"' and text[j] == "`" and j + 1 < n:
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    if j + 1 < n and text[j + 1] == quote:
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            else:
+                raise SystemExit(f"ci-guard-publish-order: unterminated {quote}-quoted string in {source}")
+            out.append(text[i:j])
+            i = j
+            continue
+        if ch == "#":
+            end = text.find("\n", i)
+            if end == -1:
+                end = n
+            out.append(" " * (end - i))
+            i = end
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def ps1_packages(text: str) -> list[str]:
-    m = re.search(r"^\$packages\s*=\s*@\(\s*$(.*?)^\)\s*$", text, re.MULTILINE | re.DOTALL)
+    scanned = _strip_ps1_comments(text, PS1)
+    m = re.search(r"^\$packages\s*=\s*@\(\s*$(.*?)^\)\s*$", scanned, re.MULTILINE | re.DOTALL)
     if not m:
         raise SystemExit(f"ci-guard-publish-order: could not locate `$packages = @(...)` in {PS1}")
     names = re.findall(r'"([^"]+)"', m.group(1))
@@ -70,7 +146,8 @@ def ps1_packages(text: str) -> list[str]:
 
 
 def ps1_nested_manifests(text: str) -> dict[str, str]:
-    m = re.search(r"^\$nestedManifest\s*=\s*@\{\s*$(.*?)^\}\s*$", text, re.MULTILINE | re.DOTALL)
+    scanned = _strip_ps1_comments(text, PS1)
+    m = re.search(r"^\$nestedManifest\s*=\s*@\{\s*$(.*?)^\}\s*$", scanned, re.MULTILINE | re.DOTALL)
     if not m:
         raise SystemExit(f"ci-guard-publish-order: could not locate `$nestedManifest = @{{...}}` in {PS1}")
     pairs = re.findall(r'"([^"]+)"\s*=\s*"([^"]+)"', m.group(1))
@@ -78,6 +155,14 @@ def ps1_nested_manifests(text: str) -> dict[str, str]:
 
 
 def sh_npm_rows(text: str) -> list[dict[str, str]]:
+    # NOT vulnerable to the .ps1 comment-blindness bug (verified, not assumed): the row table
+    # lives inside `<<'EOF' ... EOF` -- a QUOTED bash heredoc. Quoting the delimiter disables
+    # every bit of shell interpretation of the body, `#` included, so a `#`-prefixed row is not
+    # a comment to bash either: the real script still reads it as a literal (malformed) data row
+    # and fails loudly trying to build/publish it, and this parser (which never special-cases
+    # `#`) sees the same row and reports it as a mismatch. Confirmed by mutation: prefixing a row
+    # with `#` here makes `bash`'s own `mapfile` still count it (30 rows, not 29) and this
+    # function's CHECK 4 fail on the corrupted working-directory -- neither reading is fooled.
     m = re.search(r"<<'EOF'.*?\n(.*?)\nEOF\n", text, re.DOTALL)
     if not m:
         raise SystemExit(f"ci-guard-publish-order: could not locate the PACKAGES heredoc in {NPM_SH}")
@@ -101,6 +186,13 @@ def sh_npm_rows(text: str) -> list[dict[str, str]]:
 
 
 def doc_npm_table(text: str) -> tuple[list[str], int | None]:
+    # NOT vulnerable to the .ps1 comment-blindness bug (verified, not assumed): wrapping a row in
+    # an HTML comment (`<!-- | ... | --> `) hides it from a rendered markdown VIEW, but this
+    # function -- like every markdown renderer's source input -- reads the raw file text, and an
+    # HTML comment does not remove or alter that text. Confirmed by mutation: wrapping the
+    # `@lib-q/mac` row in `<!-- -->` left the guard's row count and output unchanged (still found,
+    # still OK). There is no discrepancy between what this parser sees and what a renderer hides,
+    # so there is nothing here for a `#`-style scanner fix to close.
     m = re.search(r"^## Package list \(CD order\)\s*$(.*?)^## ", text, re.MULTILINE | re.DOTALL)
     if not m:
         raise SystemExit(
@@ -186,6 +278,7 @@ def check_nested_manifests(manifest: dict, nested: dict[str, str]) -> None:
 
 def check_npm(manifest: dict, rows: list[dict[str, str]]) -> None:
     cd_by_name = {item["package"]: item for item in manifest["npm"]}
+    row_names = [row["package"] for row in rows]
     sh_by_name = {row["package"]: row for row in rows}
     for name in cd_by_name:
         if name not in sh_by_name:
@@ -193,6 +286,9 @@ def check_npm(manifest: dict, rows: list[dict[str, str]]) -> None:
     for name in sh_by_name:
         if name not in cd_by_name:
             fail("CHECK 4", f"{NPM_SH} lists {name}, which cd.yml does not publish")
+    dupes = sorted({n for n in row_names if row_names.count(n) > 1})
+    if dupes:
+        fail("CHECK 4", f"{NPM_SH} lists these packages more than once: " + ", ".join(dupes))
     for name, item in cd_by_name.items():
         row = sh_by_name.get(name)
         if row is None:
@@ -228,10 +324,24 @@ def check_doc(manifest: dict, names: list[str], total: int | None) -> None:
     for name in names:
         if name not in cd_names:
             fail("CHECK 5", f"{NPM_DOC} package table lists {name}, which cd.yml does not publish")
+    dupes = sorted({n for n in names if names.count(n) > 1})
+    if dupes:
+        fail("CHECK 5", f"{NPM_DOC} package table lists these packages more than once: " + ", ".join(dupes))
     if total is None:
         fail("CHECK 5", f"{NPM_DOC} no longer states a '**Total: N packages**' count")
-    elif total != len(cd_names):
-        fail("CHECK 5", f"{NPM_DOC} claims {total} packages; cd.yml publishes {len(cd_names)}")
+    else:
+        if total != len(cd_names):
+            fail("CHECK 5", f"{NPM_DOC} claims {total} packages; cd.yml publishes {len(cd_names)}")
+        # Compare against the number of rows actually parsed too, not just cd.yml's count: a
+        # padding duplicate row (e.g. 31 rows for 30 distinct packages, still stated as "30")
+        # would pass the membership and the above checks -- every cd.yml package is present, the
+        # stated total matches cd.yml -- while the table itself has drifted from what it claims.
+        if total != len(names):
+            fail(
+                "CHECK 5",
+                f"{NPM_DOC} claims {total} packages but its table has {len(names)} rows "
+                f"({len(set(names))} distinct)",
+            )
 
 
 def main() -> int:

--- a/scripts/publish-crates-io-ordered.ps1
+++ b/scripts/publish-crates-io-ordered.ps1
@@ -1,6 +1,17 @@
 # Publish workspace crates to crates.io in CD dependency order (.github/workflows/cd.yml).
 # Requires: cargo login (API token). Stops on first hard failure.
 # Resume: -StartAt N (0-based index into $packages below).
+#
+# $packages MIRRORS cd.yml -- it does not define the order, it restates it. A restatement drifts:
+# at 0.0.10 this list held 65 of cd.yml's 80 crates, and the 15 it omitted would not have errored,
+# they would simply never have published. scripts/ci-guard-publish-order.sh now fails any pull
+# request where the two disagree, so regenerate rather than hand-edit:
+#
+#   python3 scripts/cd_publish_manifest.py --format crates
+#
+# The guard requires the SET to match cd.yml exactly and the ORDER to respect cd.yml's job `needs`
+# DAG. Order WITHIN one cd.yml matrix job is free (those entries publish in parallel there), which
+# is what lets lib-q-blind-pcs precede lib-q-fhe below.
 param([int]$StartAt = 0)
 
 Set-Location (Join-Path $PSScriptRoot "..")
@@ -10,27 +21,45 @@ $packages = @(
     "lib-q-core", "lib-q-keccak",
     "lib-q-sha3",
     "lib-q-keccak-digest", "lib-q-utils", "lib-q-platform", "lib-q-saturnin",
-    "lib-q-random", "lib-q-hqc-traits", "lib-q-duplex-aead", "lib-q-tweak-aead",
-    "lib-q-romulus", "lib-q-ring", "lib-q-prf",
-    "lib-q-k12", "lib-q-ml-kem", "lib-q-cb-kem",
+    "lib-q-hqc-traits", "lib-q-duplex-aead", "lib-q-tweak-aead", "lib-q-romulus",
+    "lib-q-rocca-s", "lib-q-ring", "lib-q-prf",
+    "lib-q-k12", "lib-q-intrinsics",
+    "lib-q-hash",
+    "lib-q-random",
     "lib-q-fn-dsa-comm", "lib-q-fn-dsa-kgen", "lib-q-fn-dsa-sign", "lib-q-fn-dsa-vrfy", "lib-q-fn-dsa-alg",
-    "lib-q-fn-dsa", "lib-q-intrinsics",
-    "lib-q-hqc", "lib-q-slh-dsa", "lib-q-lattice-zkp",
-    "lib-q-ml-dsa", "lib-q-hash", "lib-q-aead", "lib-q-kem", "lib-q-sig", "lib-q-ring-sig",
+    "lib-q-fn-dsa",
+    "lib-q-ml-kem", "lib-q-hqc", "lib-q-slh-dsa", "lib-q-lattice-zkp", "lib-q-mayo",
+    "lib-q-cb-kem",
+    "lib-q-ml-dsa",
+    "lib-q-aead", "lib-q-kem", "lib-q-sig", "lib-q-ring-sig",
     "lib-q-hpke", "lib-q-sca-test",
+    # tier 4b. lib-q-blind-pcs precedes lib-q-fhe: they share cd.yml's tier-4b matrix (parallel
+    # there, so cd.yml imposes no order), but lib-q-fhe dev-depends on lib-q-blind-pcs, and this
+    # script publishes sequentially without the dev-dep stripping CD's crate-publish action does.
+    "lib-q-mac", "lib-q-threshold-kem", "lib-q-double-kem",
+    "lib-q-blind-pcs", "lib-q-fhe", "lib-q-dkg", "lib-q-blind-token",
+    "lib-q-threshold-raccoon",
+    "lib-q-threshold-kem-lattice",
     "lib-q-stark-util", "lib-q-stark-rayon",
-    "lib-q-stark-field", "lib-q-stark-symmetric",
-    "lib-q-stark-matrix", "lib-q-stark-dft", "lib-q-stark-commit",
-    "lib-q-stark-mds", "lib-q-stark-field-testing", "lib-q-stark-shake256",
-    "lib-q-stark-shake128", "lib-q-stark-sha3-256",
+    "lib-q-stark-field",
+    "lib-q-stark-symmetric",
+    "lib-q-stark-matrix",
+    "lib-q-stark-dft", "lib-q-stark-commit",
+    "lib-q-stark-shake256", "lib-q-stark-shake128", "lib-q-stark-sha3-256",
+    "lib-q-stark-mds", "lib-q-stark-field-testing",
     "lib-q-stark-mersenne31", "lib-q-stark-monty31",
-    "lib-q-stark-challenger", "lib-q-stark-interpolation",
-    "lib-q-poseidon", "lib-q-stark-merkle", "lib-q-stark-fri", "lib-q-stark-air",
+    "lib-q-stark-challenger", "lib-q-stark-interpolation", "lib-q-stark-baby-bear",
+    "lib-q-stark-air", "lib-q-poseidon",
+    "lib-q-stark-merkle",
+    "lib-q-stark-fri",
     "lib-q-stark",
-    "lib-q-plonky-multilinear-util", "lib-q-plonky-keccak-air",
-    "lib-q-plonky-lookup", "lib-q-plonky-uni-stark",
-    "lib-q-plonky-batch-stark", "lib-q-plonky",
+    "lib-q-plonky-multilinear-util", "lib-q-plonky-lookup",
+    "lib-q-plonky-uni-stark",
+    "lib-q-plonky-keccak-air",
+    "lib-q-plonky-batch-stark",
+    "lib-q-plonky",
     "lib-q-zkp",
+    "lib-q-mve", "lib-q-transcript", "lib-q-zk-encryption-proof",
     "lib-q"
 )
 

--- a/scripts/publish-npm-ordered.sh
+++ b/scripts/publish-npm-ordered.sh
@@ -52,6 +52,20 @@ if [[ -z "$VERSION" ]]; then
 fi
 
 # working-directory|npm name|description|keywords|features|out-dir|skip-build(1=types only)
+#
+# This table MIRRORS cd.yml's `publish-wasm-packages` matrix plus `publish-npm-types`; it does not
+# define the release. It drifts two ways, and neither errors at run time: a MISSING row silently
+# never publishes (at 0.0.10: @lib-q/dkg, @lib-q/threshold-raccoon, @lib-q/threshold-kem-lattice),
+# and a wrong `features` column ships a package built differently from CD's (at 0.0.10 @lib-q/aead
+# was built without `rocca-s`, i.e. shipped without a cipher CD includes).
+# scripts/ci-guard-publish-order.sh now fails any pull request where a row disagrees with cd.yml
+# on crate dir, features or out-dir. Regenerate rather than hand-edit:
+#
+#   python3 scripts/cd_publish_manifest.py --format npm
+#
+# Row order is NOT constrained: cd.yml publishes every wasm package from one parallel matrix, so it
+# asserts no order between them. Rows are appended rather than resorted so that START_AT indices
+# already in an operator's notes keep pointing at the same package.
 read -r -d '' PACKAGES <<'EOF' || true
 lib-q|@lib-q/core|Post-quantum cryptography library for Node.js (complete package)|cryptography,post-quantum,security,wasm|wasm,all-algorithms,ml-kem|pkg|
 lib-q-ml-kem|@lib-q/ml-kem|NIST ML-KEM (Module-Lattice-based Key Encapsulation Mechanism) for Node.js|cryptography,post-quantum,ml-kem,key-encapsulation,nist,wasm|wasm|pkg|
@@ -60,7 +74,7 @@ lib-q-sig|@lib-q/sig|Post-quantum Digital Signatures for Node.js|cryptography,po
 lib-q-hash|@lib-q/hash|Post-quantum Hash Functions for Node.js (SHA-3, SHAKE, cSHAKE, KMAC, TupleHash, ParallelHash)|cryptography,post-quantum,hash,shake,kmac,tuplehash,parallelhash,wasm|alloc,oid|pkg-hash|
 lib-q-utils|@lib-q/utils|Utility functions for post-quantum cryptography|cryptography,post-quantum,utilities,helpers,wasm||pkg-utils|
 lib-q-fn-dsa|@lib-q/fn-dsa|FN-DSA (FIPS 206) post-quantum digital signatures for Node.js|cryptography,post-quantum,fn-dsa,falcon,signature,wasm,nist|wasm,std,rand|pkg|
-lib-q-aead|@lib-q/aead|Post-quantum AEAD (Saturnin, Romulus, duplex-sponge) for Node.js|cryptography,post-quantum,aead,saturnin,wasm,nist|wasm,saturnin,romulus,duplex-sponge-aead|pkg|
+lib-q-aead|@lib-q/aead|Post-quantum AEAD (Saturnin, Romulus, Rocca-S, duplex-sponge) for Node.js|cryptography,post-quantum,aead,saturnin,romulus,rocca-s,wasm,nist|wasm,saturnin,romulus,rocca-s,duplex-sponge-aead|pkg|
 lib-q-hpke|@lib-q/hpke|Post-quantum HPKE (RFC 9180) for Node.js|cryptography,post-quantum,hpke,ml-kem,wasm|wasm,alloc,ml-kem,saturnin,shake256|pkg|
 lib-q-zkp|@lib-q/zkp|Post-quantum zero-knowledge proofs (STARK) for Node.js|cryptography,post-quantum,zkp,stark,wasm|wasm,zkp|pkg|
 lib-q-random|@lib-q/random|Secure random bytes for post-quantum libQ on Node.js and WASM|cryptography,random,entropy,wasm,getrandom|wasm|pkg|
@@ -80,6 +94,9 @@ lib-q-blind-pcs|@lib-q/blind-pcs|Experimental blind commitment demo (EXPERIMENTA
 lib-q-double-kem|@lib-q/double-kem|PROVISIONAL MAUL v1 double ML-KEM-768 for Node.js|cryptography,post-quantum,kem,ml-kem,double-kem,wasm|wasm,std,random|pkg|
 lib-q-fhe|@lib-q/fhe|Experimental toy lattice FHE demo (EXPERIMENTAL_NON_NIST)|cryptography,post-quantum,fhe,experimental,wasm|wasm,fhe|pkg|
 lib-q-threshold-kem|@lib-q/threshold-kem|PROVISIONAL threshold KEM (ML-KEM-768 + Shamir) for Node.js|cryptography,post-quantum,threshold,kem,wasm|wasm,std,random|pkg|
+lib-q-dkg|@lib-q/dkg|PROVISIONAL lattice dealerless DKG (binding BDLOP VSS) for Node.js|cryptography,post-quantum,dkg,threshold,wasm|wasm,std,random|pkg|
+lib-q-threshold-raccoon|@lib-q/threshold-raccoon|PROVISIONAL PQ lattice threshold signature (consumes lib-q-dkg shares) for Node.js|cryptography,post-quantum,threshold,signature,wasm|wasm,std,random|pkg|
+lib-q-threshold-kem-lattice|@lib-q/threshold-kem-lattice|PROVISIONAL PQ lattice threshold KEM (dealerless keygen via lib-q-dkg) for Node.js|cryptography,post-quantum,threshold,kem,wasm|wasm,std,random|pkg|
 EOF
 
 mapfile -t ROWS < <(printf '%s\n' "$PACKAGES")

--- a/scripts/publish-readiness-pr.sh
+++ b/scripts/publish-readiness-pr.sh
@@ -10,6 +10,20 @@ PKG="${1:?usage: publish-readiness-pr.sh <package>}"
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
+# Probe by RUNNING each candidate: on Windows a `python3` App Execution Alias sits on PATH and
+# satisfies `command -v` while refusing to execute (same probe as scripts/ci-guard-*.sh).
+PY_BIN=""
+for candidate in python3 python py; do
+  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="$candidate"
+    break
+  fi
+done
+if [[ -z "$PY_BIN" ]]; then
+  echo "ERROR: publish-readiness-pr.sh needs a working python3 interpreter" >&2
+  exit 1
+fi
+
 WS_VERSION="$(
   sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml \
     | grep '^version = ' \
@@ -23,7 +37,7 @@ if [[ ! -f "$MANIFEST" ]]; then
   exit 1
 fi
 
-python3 - "$MANIFEST" "$WS_VERSION" "$PKG" <<'PY'
+"$PY_BIN" - "$MANIFEST" "$WS_VERSION" "$PKG" <<'PY'
 import pathlib
 import re
 import sys
@@ -52,9 +66,21 @@ for section in sections:
         if section == "dependencies":
             has_workspace_prod = True
 
-cd = (pathlib.Path("Cargo.toml").parent / ".github/workflows/cd.yml").read_text(encoding="utf-8")
-if pkg not in re.findall(r'package:\s*"(lib-q[^"]+)"', cd):
-    raise SystemExit(f"{pkg}: missing from cd.yml publish-rust jobs")
+# cd.yml publishes a crate in one of two shapes: a quoted matrix entry (`- package: "lib-q-foo"`)
+# or an unquoted single-package step (`package: lib-q-foo`). The old check here matched only the
+# quoted form, so 20 of cd.yml's 80 crates would have been reported "missing from cd.yml" — the
+# gate was self-consistent only because every crate ci.yml actually guards happened to be a quoted
+# entry. Moving any of them to a single-package job would have false-failed this gate. Resolve the
+# list through the shared derivation instead of re-implementing the match.
+sys.path.insert(0, str(pathlib.Path("scripts").resolve()))
+from cd_publish_manifest import crate_names  # noqa: E402
+
+published = crate_names(pathlib.Path("."))
+if pkg not in published:
+    raise SystemExit(
+        f"{pkg}: missing from cd.yml publish-rust jobs "
+        f"(cd.yml publishes {len(published)} crates; add it to a publish-rust-* job)"
+    )
 
 print(f"manifest pins: OK ({pkg})")
 


### PR DESCRIPTION
`scripts/publish-crates-io-ordered.ps1` claimed to mirror `cd.yml` but listed **65 of 80** crates — an operator falling back to it would silently skip 15, with no error. It also had **48 crate pairs ordered against cd.yml's `needs` DAG**, so even the 65 it listed could publish in a failing order. The npm script was missing 3 packages and built `@lib-q/aead` without the `rocca-s` feature cd.yml uses.

Adds a single derivation point (`scripts/cd_publish_manifest.py`) plus a CI guard on every restatement, wired into `core-validation` on pull requests. Chose a guard over run-time derivation because PowerShell 7 has no built-in YAML parser, so deriving in-script would mean either the same regex fragility or a new runtime dependency on precisely the script you reach for when CD is already broken.

Adversarial review then defeated the first guard: it regex-scanned the `.ps1` without stripping PowerShell comments, so a single `#` restored the silent-skip bug while the guard reported `OK (80 crates)`. Closed with a quote-state tokenizer (handling `<# #>` blocks and escapes) rather than a naive split, which would have truncated `"foo # bar"` into a wrong crate name. Mutation-proven both directions, no false positives on legitimate comments.

Also fixes: `publish-readiness-pr.sh` matched only *quoted* matrix entries (20 of 80 crates would false-fail), a dead tab-check, a missing npm duplicate-row check, and the dry-run/real-publish `--no-verify` asymmetry.