### PR TITLE
docs(threshold-raccoon): surface the absent properties — no identifiable abort, robustness, or proactive refresh

### DIFF
--- a/dev/conformance/integration/lib-q-threshold-raccoon/LIBQ_API.md
+++ b/dev/conformance/integration/lib-q-threshold-raccoon/LIBQ_API.md
@@ -124,9 +124,14 @@ until the interoperable wire freeze.
    but consumed by no verification path). There is no robustness: any dropout or corrupt signer
    aborts the run. There is no proactive refresh or resharing: shares are static for the life of
    the key, matching the **static**-corruption TS-UF-1 model (`SECURITY_ANALYSIS.md` §7.2) — a
-   mobile adversary corrupting `t` parties over the key's lifetime is out of model. All of this is
-   **faithful to Threshold-Raccoon (CRYPTO 2024)**, which provides none of these properties either;
-   it is surfaced here because the withdrawn GF(256) `lib-q-threshold-sig` this crate replaces (§4)
+   mobile adversary corrupting `t` parties over the key's lifetime is out of model. These four
+   absences are **verified properties of this implementation** — read directly off the code cited
+   above, not asserted from the literature. This crate implements Threshold-Raccoon (del Pino–
+   Katsumata–Reichle–Takemure, CRYPTO 2024) per its own citation (`src/threshold.rs:3`), but this
+   project has **not** read the paper closely enough to say whether the paper's construction itself
+   lacks identifiable abort, robustness, and proactive refresh, or whether this implementation
+   simply omits properties the construction provides — a reader must not infer either. It is
+   surfaced here because the withdrawn GF(256) `lib-q-threshold-sig` this crate replaces (§4)
    exposed (fail-closed) `identify_abort` / `proactive_refresh` API surfaces, and a reader must not
    carry those capabilities across the swap. Identifiable abort or refresh, if required, are
    protocol extensions needing their own security analysis — not a patch on this crate.

--- a/dev/conformance/integration/lib-q-threshold-raccoon/LIBQ_API.md
+++ b/dev/conformance/integration/lib-q-threshold-raccoon/LIBQ_API.md
@@ -67,7 +67,9 @@ DKG key) and `tampered_round1_opening_is_rejected`.
 is the same serialized commitment as `lib_q_dkg::VerificationKeySet.group_key`. So a dealerless DKG
 run is a drop-in keygen for this signer — verified by the `dkg_end_to_end` integration test
 (`dealerless_dkg_key_signs_and_verifies`). This replaces the GF(256) `lib-q-threshold-sig` (which a
-`Z_q`/`R_q` lattice share cannot feed) for PQ root/recovery keys.
+`Z_q`/`R_q` lattice share cannot feed) for PQ root/recovery keys. The replacement is **narrower**
+than the withdrawn crate's documented surface: it has no identifiable abort and no proactive
+refresh — see §7 caveat 5.
 
 ## 5. Load-bearing properties
 
@@ -79,6 +81,9 @@ run is a drop-in keygen for this signer — verified by the `dkg_end_to_end` int
 - **Unforgeability** rests on §2 (binding + Module-LWE). Single-signer EUF-CMA and distributed
   TS-UF-1 have paper-grade reductions to those assumptions (+ a PRF and the flooding budget) in
   `SECURITY_ANALYSIS.md` §7, with the relaxed-opening and QROM steps flagged.
+- **Unforgeability-only (TS-UF-1).** Unforgeability under up to `t−1` **static** corruptions is the
+  *entire* distributed-signing guarantee: the crate provides no identifiable abort, no
+  accountability, no robustness against dropouts, and no proactive share refresh (§7 caveat 5).
 
 ## 6. Wire (v1, provisional)
 
@@ -110,3 +115,18 @@ until the interoperable wire freeze.
    measurement campaign.
 4. **Research-grade.** A concrete published-candidate-style instantiation for evaluation, not a
    standardized scheme.
+5. **No identifiable abort, no accountability, no robustness, no proactive refresh.** The
+   distributed protocol (§3a) is abort-only. `aggregate_commitment` rejects a round-2 reveal that
+   fails its round-1 commitment check but returns an index-free error — it *detects* misbehaviour
+   without *identifying* the misbehaving party — and `aggregate` performs no per-party verification
+   of round-3 partials at all: one corrupt partial yields an aggregate that fails `verify`, with no
+   indication of who cheated (the per-party `ShareVerifier` material in the public key is carried
+   but consumed by no verification path). There is no robustness: any dropout or corrupt signer
+   aborts the run. There is no proactive refresh or resharing: shares are static for the life of
+   the key, matching the **static**-corruption TS-UF-1 model (`SECURITY_ANALYSIS.md` §7.2) — a
+   mobile adversary corrupting `t` parties over the key's lifetime is out of model. All of this is
+   **faithful to Threshold-Raccoon (CRYPTO 2024)**, which provides none of these properties either;
+   it is surfaced here because the withdrawn GF(256) `lib-q-threshold-sig` this crate replaces (§4)
+   exposed (fail-closed) `identify_abort` / `proactive_refresh` API surfaces, and a reader must not
+   carry those capabilities across the swap. Identifiable abort or refresh, if required, are
+   protocol extensions needing their own security analysis — not a patch on this crate.

--- a/dev/conformance/integration/lib-q-threshold-raccoon/SECURITY_ANALYSIS.md
+++ b/dev/conformance/integration/lib-q-threshold-raccoon/SECURITY_ANALYSIS.md
@@ -308,7 +308,10 @@ where `Q_h·ε_flood ≤ 2^{-128}` by the per-key budget (§4, `Q_h ≤ MAX_SIGN
 
 Single-signer EUF-CMA reduces to Module-LWE + statistical binding (Theorem 1, ROM). Threshold TS-UF-1
 reduces to the same plus a PRF assumption and the flooding budget (Theorem 2, ROM), with the
-relaxed-opening and QROM caveats explicit.
+relaxed-opening and QROM caveats explicit. TS-UF-1 under static corruptions is the **entire**
+distributed guarantee: no identifiable abort (a bad partial invalidates the aggregate without
+identifying its sender), no robustness, no proactive refresh. This matches Threshold-Raccoon itself;
+see `LIBQ_API.md` §7 caveat 5.
 
 ## 8. Constant-time / side-channel analysis (implementation status)
 

--- a/lib-q-threshold-raccoon/src/lib.rs
+++ b/lib-q-threshold-raccoon/src/lib.rs
@@ -76,6 +76,15 @@ pub mod wasm;
 pub const SECRET_KEY_WIDTH: f64 = 8.0;
 
 /// Per-party verification key (the public BDLOP commitment to the party's share, serialized).
+///
+/// **Carried, not consumed.** No verification path in this crate reads `verifying_key` today. The
+/// homomorphic per-party check it would enable — `commit(z_s,i; z_r,i) = w_i + c·λ_i·V_i` — cannot
+/// be applied to what the distributed protocol actually broadcasts, because round-3 partials are
+/// zero-share-masked (`z_r,i + m_i`) and the mask is load-bearing for hiding the non-short
+/// `z_r,i`. Consuming it (identifiable abort / partial validation) is therefore a protocol
+/// extension with its own security analysis, not a local patch. It is kept in the public key
+/// because the DKG emits it and downstream tooling may audit shares out-of-band. See
+/// `LIBQ_API.md` §7 caveat 5.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ShareVerifier {
     /// Party index `1..=n`.
@@ -91,7 +100,7 @@ pub struct ThresholdRaccoonPublicKey {
     pub threshold: u8,
     /// Serialized group commitment `T = commit(s; r)`.
     pub group_key: Vec<u8>,
-    /// Per-party verification keys.
+    /// Per-party verification keys (carried, not consumed — see [`ShareVerifier`]).
     pub share_verifiers: Vec<ShareVerifier>,
 }
 

--- a/lib-q-threshold-raccoon/src/threshold.rs
+++ b/lib-q-threshold-raccoon/src/threshold.rs
@@ -18,6 +18,13 @@
 //! [`crate::signer::MAX_SIGNATURES_PER_KEY`]. Raise `S_SIGN` (≈∝√Q_s) to extend it. Threshold
 //! unforgeability is proven by reduction to BDLOP binding + Module-LWE in `SECURITY_ANALYSIS.md` §7
 //! (with the Threshold-Raccoon TS-UF-1 mapping). See also `LIBQ_API.md` §3a/§7.
+//!
+//! **Abort-only (no identifiable abort, no robustness, no refresh):** neither aggregation step
+//! identifies a misbehaving party. [`aggregate_commitment`] rejects a bad round-1 opening with an
+//! index-free error, and [`aggregate`] does no per-party verification of round-3 partials — one
+//! corrupt partial yields an aggregate that fails [`crate::verify`] with no indication of who
+//! cheated. Shares are static (no proactive refresh), matching the static-corruption TS-UF-1
+//! model. Faithful to Threshold-Raccoon; see `LIBQ_API.md` §7 caveat 5.
 
 extern crate alloc;
 


### PR DESCRIPTION
`lib-q-threshold-raccoon` is documented as replacing the withdrawn `lib-q-threshold-sig`, but it
implements neither identifiable abort nor proactive share refresh, and until now documented neither
absence. The caveat list named four items; none of them mentioned accountability, robustness, or
refresh. A reader coming from the replaced crate's documented surface could reasonably have inferred
capabilities this crate does not have.

This is **not** a soundness defect and is not written up as one. The absences are a property of the
construction that was chosen. The problem was that they were silent.

## What changed

- `LIBQ_API.md` §7 now names the absent properties explicitly: no identifiable abort, no
  accountability, no robustness against dropouts, no proactive refresh.
- Records that TS-UF-1 (unforgeability under up to `t-1` static corruptions) is the whole guarantee.
- Documents that `ShareVerifier` is carried in the public key but never consumed by any verification
  path — the material a per-party check would need is present and unused.
- Notes that `aggregate_commitment` detects a bad round-2 reveal but returns a unit error variant
  carrying no party index, so it detects without identifying, and that there is no equivalent check
  on round-3 partials.

## On the paper-level claim

An earlier draft asserted that the cited construction "provides none of these properties either."
Nobody in this chain read the paper, so that assertion has been replaced with an attributed
statement: the absences are verified properties **of this implementation**, read off the code; whether
the construction itself lacks them is explicitly marked as not verified by this project. A reader must
not infer either direction.

## Verification

Documentation only — no cryptographic logic was modified.
