### PR TITLE
fix(ci): close the two release-guard gaps v0.0.11 shipped through

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,6 +75,16 @@ jobs:
       - name: Guard against publishing on top of a yanked dependency (registry drift)
         run: bash ./scripts/ci-guard-yanked-deps.sh --published .
 
+      # ci.yml runs this guard's static half on every PR. Here we run the TRUE predicate: actually
+      # `cargo build -p <crate> --lib` (bare default features, host) every publishable cdylib crate
+      # whose defaults do not enable `std`, so the KNOWN_LINKABLE allowlist cannot rot into a stale
+      # claim. This is the combination `cargo publish --verify` builds and nothing else does; when
+      # it fails during publishing instead of here, earlier crates are already immutable on
+      # crates.io and the release can only be completed, never rolled back (v0.0.11, 35 crates in).
+      # Runs before anything is built or published, and its own exit code is the step's.
+      - name: Guard cdylib crates link with bare default features (publish --verify's combination)
+        run: bash ./scripts/ci-guard-cdylib-default-link.sh --build
+
       - name: Run comprehensive validation
         uses: ./.github/actions/rust-build
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,19 @@ jobs:
       - name: Guard cd.yml publish tiers against the dependency graph
         run: bash ./scripts/ci-guard-publish-dependency-order.sh
 
+      # Both guards above ask whether the publish ORDER is possible. This one asks whether a crate
+      # can be PACKAGED AT ALL, which is a different failure and the one that killed v0.0.11 at
+      # tier 3: `cargo publish --verify` builds with BARE DEFAULT FEATURES ON THE HOST, and no CI
+      # job builds that combination. `lib-q-kem` (crate-type cdylib) had `default = []` plus
+      # `lib-q-core = { default-features = false }`, so a native cdylib was asked to link against a
+      # no_std core -- "unwinding panics are not supported without std". `--all-features` cannot
+      # see this (it turns std on) and the thumbv7em no_std build has no cdylib to link, so the
+      # defect reached a tag with everything green and 35 crates shipped before it surfaced.
+      # Static here (one `cargo metadata`, no build, no network) so it runs on every PR; cd.yml
+      # runs the same guard with --build to actually link the allowlisted crates before releasing.
+      - name: Guard cdylib crates against a non-linking default feature set
+        run: bash ./scripts/ci-guard-cdylib-default-link.sh
+
       # The sibling gap to BOTH guards above: those check that publish order/tiers are
       # satisfiable at package time; this one checks that a lib-q-* crate is not shipped
       # depending on a version of another lib-q-* crate that crates.io has YANKED. Real incident:

--- a/docs/crates-io-publish.md
+++ b/docs/crates-io-publish.md
@@ -14,7 +14,15 @@ Internal `path` dependencies must include a **version** (same as `[workspace.pac
 
 **`lib-q` umbrella (tier 17)**: publish last (after `lib-q-zkp`, `lib-q-mve` + `lib-q-transcript`, and other path dependencies). Configure Trusted Publishing on the crate the same way as the rest of the workspace ([docs](https://crates.io/docs/trusted-publishing)).
 
-**Bump:** When the workspace version changes, update every internal `version = "…"` on path dependencies to match, or re-run the script with `WS_VERSION` updated.
+**Bump:** When the workspace version changes, every internal `version = "…"` on a path dependency must move with it — 434 pins across 84 manifests at 0.0.11. Use the bumper rather than doing it by hand or with a blanket search-and-replace:
+
+```bash
+python3 scripts/bump-workspace-version.py --to 0.0.12 --npm                  # dry run first
+python3 scripts/bump-workspace-version.py --to 0.0.12 --npm --apply
+python3 scripts/bump-workspace-version.py --to 0.0.11 --report-docs          # triage docs BY HAND
+```
+
+`--npm` also fixes `npm/**/package.json`, which drifts invisibly because CD overwrites the version at publish time (`npm pkg set version=`) — at 0.0.11 `npm/lib-q-types/package.json` still said `0.0.2`. `--report-docs` **lists and never rewrites**: most matches are history (a CHANGELOG heading, a "fixed in 0.0.10" note) and some are deliberately pinned to the old version. At 0.0.11 both `lib-q-hqc/SECURITY.md` and `lib-q-types/src/hqc.rs` correctly said `lib-q-types <= 0.0.10`, describing a break that ships *in* 0.0.11; a blanket replace falsifies them.
 
 **Not every workspace member is in `cd.yml`.** A member stays path-only until it is added to a publish tier. As of 0.0.10 the only members `cd.yml` does not publish are the ones that carry `publish = false` in their own `[package]` (a withdrawn crate, and `examples/`) — the research and internal crates this note used to list as path-only (`lib-q-lattice-zkp`, `lib-q-ring-sig`, `lib-q-prf`, `lib-q-sca-test`, `lib-q-ring`) have all since been added to tiers and do publish. Do not read a crate's publish status off this paragraph; derive it:
 
@@ -30,3 +38,40 @@ python3 scripts/cd_publish_manifest.py --format crates    # what cd.yml publishe
 - `lib-q-stark-baby-bear` (tier 10), `lib-q-mve`, and `lib-q-transcript` (tier 16b) are also crates.io-only; they are not in any tier whose guard requires a matching npm package, so they need no explicit exemption.
 
 **npm:** After Rust tiers through `lib-q` (umbrella), publish `@lib-q/*` with [npm-publish.md](npm-publish.md) (`scripts/publish-npm-ordered.sh` / `.ps1`).
+
+## The failure class CI cannot see: `cargo publish --verify`'s build
+
+`cargo publish --verify` builds each crate with **bare default features, on the host**. No CI job
+builds that combination — CI builds `--all-features`, `std,all-algorithms`, and
+`--no-default-features` cross-compiled to `thumbv7em-none-eabi`. So a crate can be green everywhere
+and still fail to package.
+
+v0.0.11 shipped 35 crates and then died at tier 3:
+
+```
+error: unwinding panics are not supported without std
+error: could not compile `lib-q-core` (lib) due to 1 previous error
+```
+
+`lib-q-kem` declares `crate-type = ["cdylib", "rlib"]`, and a native cdylib needs a panic runtime.
+That cycle tightened its dependency to `lib-q-core = { default-features = false }` while its own
+`default` was `[]`, so the bare-default host build put `lib-q-core` in `no_std`. `--all-features`
+structurally cannot catch this (it turns `std` on); the `thumbv7em` no_std build is a different
+target with no cdylib to link. Fixed with `default = ["std"]`.
+
+`scripts/ci-guard-cdylib-default-link.sh` now covers it, in two modes:
+
+```bash
+bash scripts/ci-guard-cdylib-default-link.sh            # static shape check — every PR (ci.yml)
+bash scripts/ci-guard-cdylib-default-link.sh --build    # really links them — release path (cd.yml)
+```
+
+The static shape (cdylib whose `default` does not reach `std`) is **necessary but not sufficient**:
+`lib-q-blind-pcs`, `lib-q-hpke` and `lib-q-stark` have exactly that shape and link fine, so they sit
+in the guard's `KNOWN_LINKABLE` allowlist. `--build` re-proves every allowlist entry with a real
+`cargo build -p <crate> --lib` before anything is published, so an entry cannot rot into a stale
+claim. **Do not add a crate to that allowlist without running the build and recording the date.**
+
+If you add a crate with `crate-type = ["cdylib", …]`, give it `default = ["std"]` — the pattern
+`lib-q-core`, `lib-q-intrinsics` and `lib-q-kem` all use. `no_std` consumers are unaffected: they
+depend with `default-features = false` and select algorithm features explicitly.

--- a/scripts/bump-workspace-version.py
+++ b/scripts/bump-workspace-version.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Bump every live version pin in the workspace from one release to the next.
+
+WHY THIS EXISTS
+---------------
+`[workspace.package] version` is inherited, but this workspace ALSO carries hundreds of explicit
+`version = "X.Y.Z"` pins on internal path dependencies (434 of them at 0.0.11), because a path
+dependency without a version is stripped from the published manifest and would break consumers.
+Bumping those by hand is not viable, and missing one is not a build error -- `cargo publish` fails
+on it mid-release, after earlier crates are already immutable on crates.io.
+
+WHAT IT TOUCHES, AND WHAT IT DELIBERATELY DOES NOT
+---------------------------------------------------
+  * Cargo.toml under the workspace  -- REWRITTEN. The exact token `version = "<from>"`, any spacing.
+  * npm/**/package.json             -- REWRITTEN with --npm. These drift silently: CD overwrites the
+                                       version at publish time via `npm pkg set version=`, so a
+                                       stale number in git is invisible until someone reads the file.
+                                       At 0.0.11, npm/lib-q-types/package.json still said "0.0.2".
+  * docs / README / *.md / *.sh     -- REPORTED ONLY, never rewritten. Most matches are HISTORY
+                                       ("fixed in 0.0.10", a CHANGELOG heading, a compatibility
+                                       statement) and bumping them rewrites the past. Some are live
+                                       install snippets that must move. Telling them apart needs
+                                       judgment, so this prints the candidates with file:line and
+                                       leaves the edit to a human.
+
+  reference/ is excluded: vendored upstream crates are versioned independently of this workspace.
+
+THE TRAP THE REPORT MODE EXISTS FOR: at 0.0.11 two doc pins were CORRECT to leave at 0.0.10 --
+lib-q-hqc/SECURITY.md and lib-q-types/src/hqc.rs both say `lib-q-types <= 0.0.10`, describing a
+breaking change that ships IN 0.0.11. A blanket search-and-replace silently falsifies both.
+
+Usage:
+  python3 scripts/bump-workspace-version.py --to 0.0.12                  # dry run, infers --from
+  python3 scripts/bump-workspace-version.py --to 0.0.12 --apply --npm
+  python3 scripts/bump-workspace-version.py --to 0.0.12 --apply --npm --report-docs
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKIP_DIRS = {"reference", "target", ".git", "scratchpad", "node_modules", "pkg"}
+DOC_SUFFIXES = {".md", ".sh", ".yml", ".yaml", ".rs", ".ps1", ".toml", ".json", ".mjs", ".ts"}
+
+
+def skipped(path: Path) -> bool:
+    return any(part in SKIP_DIRS for part in path.relative_to(ROOT).parts)
+
+
+def workspace_version() -> str | None:
+    """Read `version` from the root Cargo.toml's [workspace.package] block."""
+    text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    block = re.search(r"^\[workspace\.package\](.*?)(?=^\[)", text, re.S | re.M)
+    if not block:
+        return None
+    m = re.search(r'^version\s*=\s*"([^"]+)"', block.group(1), re.M)
+    return m.group(1) if m else None
+
+
+def bump_manifests(old: str, new: str, apply: bool) -> tuple[int, int]:
+    pat = re.compile(r'(version\s*=\s*")' + re.escape(old) + r'(")')
+    files = hits = 0
+    for man in sorted(ROOT.rglob("Cargo.toml")):
+        if skipped(man):
+            continue
+        text = man.read_text(encoding="utf-8")
+        new_text, n = pat.subn(r"\g<1>" + new + r"\g<2>", text)
+        if not n:
+            continue
+        files += 1
+        hits += n
+        print(f"  {n:4d}  {man.relative_to(ROOT).as_posix()}")
+        if apply:
+            man.write_text(new_text, encoding="utf-8")
+    return files, hits
+
+
+def bump_npm(old: str, new: str, apply: bool) -> int:
+    """Bump the top-level "version" of each npm/**/package.json.
+
+    Matches ANY current value, not just `old`: these drift out of step with the workspace precisely
+    because nothing reads them, so requiring them to already be at `old` would skip the stale ones
+    that most need fixing. Each pre-existing value is printed so a surprise is visible.
+    """
+    pat = re.compile(r'^(\s*"version"\s*:\s*")([^"]+)(")', re.M)
+    changed = 0
+    for pkg in sorted((ROOT / "npm").rglob("package.json")):
+        if skipped(pkg):
+            continue
+        text = pkg.read_text(encoding="utf-8")
+        m = pat.search(text)
+        if not m or m.group(2) == new:
+            continue
+        note = "" if m.group(2) == old else f"   <-- NOT at {old}; was adrift"
+        print(f"  {m.group(2):>10} -> {new}  {pkg.relative_to(ROOT).as_posix()}{note}")
+        changed += 1
+        if apply:
+            pkg.write_text(pat.sub(r"\g<1>" + new + r"\g<3>", text, count=1), encoding="utf-8")
+    return changed
+
+
+def report_docs(old: str) -> int:
+    """Print every remaining mention of `old` outside manifests. NEVER rewrites."""
+    found = 0
+    for path in sorted(ROOT.rglob("*")):
+        if not path.is_file() or path.suffix not in DOC_SUFFIXES or skipped(path):
+            continue
+        if path.name in ("Cargo.toml", "Cargo.lock"):
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for i, line in enumerate(lines, 1):
+            if old in line:
+                print(f"  {path.relative_to(ROOT).as_posix()}:{i}: {line.strip()[:110]}")
+                found += 1
+    return found
+
+
+def residual_manifests(old: str) -> list[str]:
+    out = []
+    for man in sorted(ROOT.rglob("Cargo.toml")):
+        if skipped(man):
+            continue
+        for i, line in enumerate(man.read_text(encoding="utf-8").splitlines(), 1):
+            if old in line:
+                out.append(f"{man.relative_to(ROOT).as_posix()}:{i}: {line.strip()}")
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Bump workspace version pins.")
+    ap.add_argument("--to", required=True, help="new version, e.g. 0.0.12")
+    ap.add_argument("--from", dest="frm", help="current version (default: [workspace.package] version)")
+    ap.add_argument("--apply", action="store_true", help="write changes (default: dry run)")
+    ap.add_argument("--npm", action="store_true", help="also bump npm/**/package.json")
+    ap.add_argument("--report-docs", action="store_true",
+                    help="list remaining mentions outside manifests for MANUAL review")
+    args = ap.parse_args()
+
+    old = args.frm or workspace_version()
+    if not old:
+        print("could not determine the current version; pass --from", file=sys.stderr)
+        return 1
+    if old == args.to:
+        print(f"--from and --to are both {old}; nothing to do", file=sys.stderr)
+        return 1
+
+    mode = "APPLY" if args.apply else "DRY RUN"
+    print(f"{mode}: {old} -> {args.to}\n\nCargo.toml pins:")
+    files, hits = bump_manifests(old, args.to, args.apply)
+    print(f"  = {hits} pin(s) across {files} manifest(s)")
+
+    if args.npm:
+        print("\nnpm package.json versions:")
+        n = bump_npm(old, args.to, args.apply)
+        print(f"  = {n} package(s)")
+
+    # Residual check. Only meaningful after --apply; a dry run has of course changed nothing.
+    if args.apply:
+        left = residual_manifests(old)
+        if left:
+            print(f"\nRESIDUAL {old} still in manifests ({len(left)}) -- these were NOT the "
+                  f"`version = \"...\"` form and need a look:")
+            for entry in left:
+                print("  " + entry)
+        else:
+            print(f"\nNo residual {old} in workspace manifests.")
+
+    if args.report_docs:
+        print(f"\nMentions of {old} OUTSIDE manifests -- REVIEW BY HAND, do not blanket-replace.")
+        print("A live install snippet must move; a CHANGELOG entry, a 'fixed in' note or a")
+        print("compatibility statement like 'lib-q-types <= 0.0.10' must NOT.")
+        found = report_docs(old)
+        print(f"  = {found} line(s) to triage")
+
+    if not args.apply:
+        print("\n(dry run -- re-run with --apply to write)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci-guard-cdylib-default-link.sh
+++ b/scripts/ci-guard-cdylib-default-link.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Guard: a publishable cdylib crate must link with BARE DEFAULT FEATURES on the host -- the one
+# combination `cargo publish --verify` builds and CI never does.
+#
+# WHY THIS EXISTS
+# ---------------
+# v0.0.11 published 35 crates and then died at tier 3 with
+#
+#     error: unwinding panics are not supported without std
+#     error: could not compile `lib-q-core` (lib) due to 1 previous error
+#
+# because `lib-q-kem` (crate-type = ["cdylib", "rlib"]) had `default = []` while its `lib-q-core`
+# dependency was tightened to `default-features = false`. Every CI job was green: `--all-features`
+# structurally cannot see this (it turns `std` on), and the `thumbv7em-none-eabi` no_std build is a
+# different target with no cdylib to link. crates.io versions are immutable, so the half-release
+# could only be completed, never rolled back.
+#
+# See scripts/ci_guard_cdylib_default_link.py for the two modes (`--static` on every PR,
+# `--build` on the release path) and why the static shape alone is necessary but not sufficient.
+#
+# Usage:
+#   bash scripts/ci-guard-cdylib-default-link.sh            # static shape check (every PR)
+#   bash scripts/ci-guard-cdylib-default-link.sh --build    # really link them (release path)
+#   bash scripts/ci-guard-cdylib-default-link.sh --self-test
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+# Probe by RUNNING each candidate: on Windows a `python3` App Execution Alias sits on PATH and
+# satisfies `command -v` while refusing to execute.
+PY_BIN=""
+for candidate in python3 python py; do
+  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "import sys" >/dev/null 2>&1; then
+    PY_BIN="$candidate"
+    break
+  fi
+done
+if [[ -z "$PY_BIN" ]]; then
+  echo "ci-guard-cdylib-default-link: a working python3 interpreter is required" >&2
+  exit 1
+fi
+
+# No pipe here: the guard's own exit code must be what this script reports. `cmd | tail` would
+# report tail's status and turn a real violation into a green step.
+"$PY_BIN" scripts/ci_guard_cdylib_default_link.py "$@"

--- a/scripts/ci-guard-yanked-deps.sh
+++ b/scripts/ci-guard-yanked-deps.sh
@@ -64,7 +64,8 @@
 #     GET /crates/<crate-name>/<version>/dependencies.
 #     A missing or empty fixture file is treated exactly like a network failure: FAIL.
 #   YANK_GUARD_PUBLISHED_CRATES="name1 name2 ..." (mode 2 only) overrides crate-list discovery.
-#   YANK_GUARD_WS_VERSION=X.Y.Z (mode 2 only) overrides workspace-version discovery.
+#     (Mode 2 has no workspace-version knob: it resolves each crate's latest LIVE version from the
+#     registry response. Auditing the workspace version is the bug it was rewritten to fix.)
 #
 # Usage:
 #   bash scripts/ci-guard-yanked-deps.sh [REPO_ROOT]              # mode 1: Cargo.lock, every PR
@@ -312,37 +313,51 @@ list_published_crates() {
     -name "Cargo.toml" -print 2>/dev/null)
 }
 
-# get_workspace_version <root>
-get_workspace_version() {
-  local root="$1"
-  if [[ -n "${YANK_GUARD_WS_VERSION:-}" ]]; then
-    printf '%s' "$YANK_GUARD_WS_VERSION"
+# latest_live_version <crate-json>
+# Prints the highest version of a crate that is currently NON-YANKED on crates.io, or nothing if
+# the crate is fully yanked / has no versions.
+#
+# Prefers crates.io's own `crate.max_stable_version` (which already excludes yanked releases) and
+# falls back to the first non-yanked entry in `.versions`, which the API returns newest-first. The
+# fallback is what keeps the self-test fixtures (bare `{"versions":[...]}` objects) meaningful.
+latest_live_version() {
+  local json="$1"
+  local v
+  v="$(printf '%s' "$json" | jq -r '.crate.max_stable_version // empty' 2>/dev/null)"
+  if [[ -n "$v" && "$v" != "null" ]]; then
+    printf '%s' "$v"
     return
   fi
-  awk '
-    /^\[workspace\.package\]/ { in_block=1; next }
-    /^\[/ { in_block=0 }
-    in_block && /^version[[:space:]]*=/ { print; exit }
-  ' "$root/Cargo.toml" 2>/dev/null | sed -E 's/.*"([^"]*)".*/\1/'
+  printf '%s' "$json" | jq -r 'first(.versions[]? | select(.yanked == false) | .num) // empty' 2>/dev/null
 }
 
 # published_mode <root>
-# Populates PROBLEMS and FAILS[]. For every published crate that is currently LIVE (non-yanked)
-# at the workspace version, fetch its registry dependency list and fail on any lib-q-* dependency
-# that is fully yanked (no non-yanked version exists anywhere for it).
+# Populates PROBLEMS and FAILS[]. For every published crate, fetch the registry dependency list of
+# its LATEST LIVE (non-yanked) version and fail on any lib-q-* dependency that is fully yanked.
+#
+# WHY THE LATEST LIVE VERSION AND NOT THE WORKSPACE VERSION
+# ---------------------------------------------------------
+# This mode used to audit crates at `[workspace.package] version`, and was VACUOUS everywhere it
+# actually ran. It is wired into cd.yml's pre-release-validation, which runs on a tag, *before*
+# anything is published -- and cd.yml's own "Validate version consistency" step fails the release
+# unless the tag equals the workspace version. So the version being audited was, by construction,
+# the one not yet on crates.io: every crate reported `missing`, every crate was skipped by
+#
+#     [[ "$ver_status" != "false" ]] && continue
+#
+# and the guard passed without examining a single dependency, every release. OBSERVED at the
+# 0.0.11 release: `curl .../crates/lib-q-core` reported `0.0.11: MISSING, 0.0.10: live`.
+#
+# The artifacts that can actually suffer post-publication yank drift are the ones already on the
+# registry, so that is what this now audits. The version is resolved PER CRATE rather than from one
+# workspace number: crates enter and leave the workspace between releases, so they are not all live
+# at the same version (and after a half-shipped release like v0.0.11's first two attempts, they are
+# demonstrably not).
 published_mode() {
   local root="$1"
   PROBLEMS=0
   FAILS=()
-  local wsver crates name json ver_status deps_json dep any_live depjson
-
-  wsver="$(get_workspace_version "$root")"
-  if [[ -z "$wsver" ]]; then
-    echo "ci-guard-yanked-deps --published: could not determine workspace version" >&2
-    PROBLEMS=$((PROBLEMS + 1))
-    FAILS+=("(setup) could not determine workspace version -- treated as FAIL")
-    return
-  fi
+  local crates name json auditver deps_json dep any_live depjson audited=0
 
   crates="$(list_published_crates "$root")"
   if [[ -z "$crates" ]]; then
@@ -357,12 +372,15 @@ published_mode() {
     [[ -z "$name" ]] && continue
     json="$(fetch_crate_json "$name")" || { PROBLEMS=$((PROBLEMS + 1)); FAILS+=("$name: could not verify (network/data error)"); continue; }
 
-    ver_status="$(printf '%s' "$json" | jq -r --arg v "$wsver" '[.versions[] | select(.num == $v) | .yanked] | if length == 0 then "missing" else (.[0] | tostring) end')"
-    # Not live at the workspace version (not yet published under it, or yanked) -> nothing to
-    # audit for THIS crate; its own yanked-ness is not what this guard checks.
-    [[ "$ver_status" != "false" ]] && continue
+    # The crate's newest version that is still live. Empty means the crate is fully yanked or has
+    # never been published -- in either case there is no live artifact of ours pointing at anything,
+    # so there is nothing for THIS guard to audit. Note this is a genuine "nothing to check", unlike
+    # the workspace-version skip it replaces, which fired for every crate on every release.
+    auditver="$(latest_live_version "$json")"
+    [[ -z "$auditver" || "$auditver" == "null" ]] && continue
+    audited=$((audited + 1))
 
-    deps_json="$(fetch_deps_json "$name" "$wsver")" || { PROBLEMS=$((PROBLEMS + 1)); FAILS+=("$name@$wsver: could not verify dependency list (network/data error)"); continue; }
+    deps_json="$(fetch_deps_json "$name" "$auditver")" || { PROBLEMS=$((PROBLEMS + 1)); FAILS+=("$name@$auditver: could not verify dependency list (network/data error)"); continue; }
 
     while IFS= read -r dep; do
       # `read` splits on \n only; jq on this platform emits trailing \r before its \n even for
@@ -371,14 +389,23 @@ published_mode() {
       # silently misses its fixture/registry entry.
       dep="${dep%$'\r'}"
       [[ -z "$dep" ]] && continue
-      depjson="$(fetch_crate_json "$dep")" || { PROBLEMS=$((PROBLEMS + 1)); FAILS+=("$name@$wsver -> $dep: could not verify (network/data error)"); continue; }
+      depjson="$(fetch_crate_json "$dep")" || { PROBLEMS=$((PROBLEMS + 1)); FAILS+=("$name@$auditver -> $dep: could not verify (network/data error)"); continue; }
       any_live="$(printf '%s' "$depjson" | jq -r '[.versions[] | select(.yanked == false)] | length')"
       if [[ "$any_live" == "0" ]]; then
         PROBLEMS=$((PROBLEMS + 1))
-        FAILS+=("$name@$wsver -> $dep: dependency crate is FULLY YANKED (no live version anywhere) while $name@$wsver is still live -- registry drift")
+        FAILS+=("$name@$auditver -> $dep: dependency crate is FULLY YANKED (no live version anywhere) while $name@$auditver is still live -- registry drift")
       fi
     done < <(printf '%s' "$deps_json" | jq -r '.dependencies[]? | select(.crate_id | startswith("lib-q-")) | .crate_id' | sort -u)
   done <<< "$crates"
+
+  # A run that audited nothing is the vacuity this mode was rewritten to end. Reaching zero here
+  # means either discovery or the live-version resolution is broken, and a silent pass would look
+  # exactly like a clean registry. Fail instead, and say which it was.
+  if [[ $audited -eq 0 ]]; then
+    PROBLEMS=$((PROBLEMS + 1))
+    FAILS+=("(setup) audited ZERO crates -- no discovered crate has a live version on crates.io. That is what the old workspace-version bug looked like; treated as FAIL, not pass")
+  fi
+  AUDITED=$audited
 }
 
 # ---------------------------------------------------------------------------------------------
@@ -553,7 +580,7 @@ JSON
   cat > "$fixtures/lib-q-live-consumer-0.0.10-deps.json" <<'JSON'
 {"dependencies":[{"crate_id":"lib-q-clean-dep","req":"^0.0.10"}]}
 JSON
-  YANK_GUARD_PUBLISHED_CRATES="lib-q-live-consumer" YANK_GUARD_WS_VERSION="0.0.10" \
+  YANK_GUARD_PUBLISHED_CRATES="lib-q-live-consumer" \
     YANK_GUARD_FIXTURE_DIR="$fixtures" published_mode "$tmp"
   if [[ $PROBLEMS -ne 0 ]]; then
     echo "  MUTATION-CHECK FAIL (I): --published mode, live crate + live dep must not fire (got $PROBLEMS: ${FAILS[*]:-})"
@@ -567,7 +594,7 @@ JSON
   cat > "$fixtures/lib-q-live-consumer-0.0.10-deps.json" <<'JSON'
 {"dependencies":[{"crate_id":"lib-q-bad-dep","req":"^0.0.10"}]}
 JSON
-  YANK_GUARD_PUBLISHED_CRATES="lib-q-live-consumer" YANK_GUARD_WS_VERSION="0.0.10" \
+  YANK_GUARD_PUBLISHED_CRATES="lib-q-live-consumer" \
     YANK_GUARD_FIXTURE_DIR="$fixtures" published_mode "$tmp"
   if [[ $PROBLEMS -eq 0 ]]; then
     echo "  MUTATION-CHECK FAIL (J): --published mode must fire when a live crate depends on a fully-yanked crate"
@@ -576,10 +603,42 @@ JSON
 
   # === Case K (--published mode, network-failure discipline): unreachable fixture dir -> MUST fail ===
   cases=$((cases + 1))
-  YANK_GUARD_PUBLISHED_CRATES="lib-q-live-consumer" YANK_GUARD_WS_VERSION="0.0.10" \
+  YANK_GUARD_PUBLISHED_CRATES="lib-q-live-consumer" \
     YANK_GUARD_FIXTURE_DIR="$tmp/this-fixture-dir-does-not-exist" published_mode "$tmp"
   if [[ $PROBLEMS -eq 0 ]]; then
     echo "  MUTATION-CHECK FAIL (K): --published mode network failure must FAIL, not silently pass"
+    problems=1
+  fi
+
+  # === Case L (THE VACUITY REGRESSION -- the whole point of the rewrite): the RELEASE-PATH shape.
+  # The workspace has been bumped to a version that is NOT yet on crates.io (which is exactly the
+  # state cd.yml runs this guard in, since it fails the release unless tag == workspace version).
+  # The crate's live 0.0.10 release depends on a now-fully-yanked crate. The OLD implementation
+  # audited the workspace version, found it `missing`, skipped the crate, and returned 0 -- passing
+  # the one incident this mode exists to catch. It MUST fire. ===
+  cases=$((cases + 1))
+  cat > "$fixtures/lib-q-live-consumer-0.0.10-deps.json" <<'JSON'
+{"dependencies":[{"crate_id":"lib-q-bad-dep","req":"^0.0.10"}]}
+JSON
+  YANK_GUARD_PUBLISHED_CRATES="lib-q-live-consumer" \
+    YANK_GUARD_FIXTURE_DIR="$fixtures" published_mode "$tmp"
+  if [[ $PROBLEMS -eq 0 ]]; then
+    echo "  MUTATION-CHECK FAIL (L): with the workspace bumped to an UNPUBLISHED version (the release-path state), the guard must still audit the crate's latest LIVE version and fire -- passing here is the vacuity bug"
+    problems=1
+  fi
+  if [[ ${AUDITED:-0} -ne 1 ]]; then
+    echo "  MUTATION-CHECK FAIL (L): expected exactly 1 crate to be audited at its live version (AUDITED=${AUDITED:-unset})"
+    problems=1
+  fi
+
+  # === Case M: a crate with NO live version anywhere -> nothing to audit, and auditing nothing at
+  # all must FAIL rather than report a clean registry. This is the tripwire that would have made
+  # the original bug loud instead of silent. ===
+  cases=$((cases + 1))
+  YANK_GUARD_PUBLISHED_CRATES="lib-q-bad-dep" \
+    YANK_GUARD_FIXTURE_DIR="$fixtures" published_mode "$tmp"
+  if [[ $PROBLEMS -eq 0 ]]; then
+    echo "  MUTATION-CHECK FAIL (M): a run that audits ZERO crates must FAIL, not read as clean"
     problems=1
   fi
 
@@ -617,7 +676,9 @@ if [[ $PUBLISHED_MODE -eq 1 ]]; then
     done
     exit 1
   fi
-  echo "ci-guard-yanked-deps --published: OK -- no live published lib-q-* crate depends on a fully-yanked crate"
+  # Report the count, not just "OK": this mode passed vacuously on every release while auditing
+  # zero crates, and the output gave no way to tell that from a clean registry.
+  echo "ci-guard-yanked-deps --published: OK -- audited ${AUDITED:-0} live crate(s); none depends on a fully-yanked crate"
   exit 0
 fi
 

--- a/scripts/ci_guard_cdylib_default_link.py
+++ b/scripts/ci_guard_cdylib_default_link.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Guard: a publishable cdylib crate must LINK with bare default features on the host.
+
+WHY THIS EXISTS
+---------------
+The v0.0.11 release published 35 crates and then died at tier 3:
+
+    error: unwinding panics are not supported without std
+    error: could not compile `lib-q-core` (lib) due to 1 previous error
+    error: failed to verify package tarball
+
+`lib-q-kem` declares `crate-type = ["cdylib", "rlib"]`. A native cdylib needs a panic runtime.
+That cycle tightened its dependency to `lib-q-core = { default-features = false }` while its own
+`default` was `[]`, so a bare-default host build put `lib-q-core` in `no_std` and the cdylib could
+not link. Fixed with `default = ["std"]`.
+
+**Every CI job was green.** `cargo publish --verify` builds the crate with BARE DEFAULT FEATURES ON
+THE HOST, and CI never builds that combination -- it builds `--all-features`, `std,all-algorithms`,
+and `--no-default-features` cross-compiled to `thumbv7em-none-eabi`. None of those is the failing
+one. `--all-features` structurally cannot see it (it turns `std` on). So the defect reached a tag
+with nothing red, and crates.io versions are immutable: a partial release can only be completed.
+
+TWO MODES, BECAUSE THE CHEAP CHECK AND THE TRUE CHECK ARE DIFFERENT QUESTIONS
+-----------------------------------------------------------------------------
+The static shape (cdylib + default does not reach `std`) is NECESSARY but NOT SUFFICIENT. OBSERVED:
+`lib-q-blind-pcs` has exactly that shape and publishes clean -- nothing in its bare-default graph
+forces a `no_std` core. Failing on the shape alone would be a false positive on a crate that works.
+
+  * `--static` (default) -- stdlib-only, one `cargo metadata` call, no build, no network. Flags any
+    publishable cdylib crate whose default features do not reach its own `std` feature AND which is
+    not in KNOWN_LINKABLE below. Cheap enough for every PR. A NEW crate of this shape fails here
+    until someone builds it and records the evidence in the allowlist.
+
+  * `--build` -- the true predicate: actually runs `cargo build -p <crate> --lib` (bare default
+    features) for every statically-flagged crate, allowlisted or not, and requires exit 0. This is
+    what stops the allowlist from rotting: an entry that stops linking goes red here. Belongs on the
+    release path, before anything is published.
+
+Using a plain `cargo build` rather than `cargo publish --dry-run` is deliberate and verified: it
+reproduces the identical failure without needing dependencies to exist on crates.io yet, so it can
+run BEFORE the release instead of during it. OBSERVED on 2026-08-13 at commit 8788981, by reverting
+`lib-q-kem`'s `default = ["std"]` back to `default = []` on the real tree:
+
+    $ cargo build -p lib-q-kem --lib          # mutated
+    error: unwinding panics are not supported without std
+    error: could not compile `lib-q-core` (lib) due to 1 previous error
+    MUTATED_BUILD_EXIT=101
+    $ cargo build -p lib-q-kem --lib          # restored
+    EXIT=0
+
+Usage:
+  python3 scripts/ci_guard_cdylib_default_link.py            # --static (every PR)
+  python3 scripts/ci_guard_cdylib_default_link.py --build    # release path: really build suspects
+  python3 scripts/ci_guard_cdylib_default_link.py --self-test
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Publishable cdylib crates whose default features do NOT reach `std`, and which have nonetheless
+# been OBSERVED to link with bare default features on the host. Each entry is a claim backed by a
+# real build; `--build` mode re-proves every one of them on the release path, so a stale entry
+# cannot stay green. Do NOT add a crate here without running the build and recording the date.
+#
+#   lib-q-blind-pcs  -- `cargo publish -p lib-q-blind-pcs --dry-run` exit 0 (2026-08-12)
+#   lib-q-hpke       -- `cargo publish -p lib-q-hpke --dry-run`      exit 0 (2026-08-13)
+#   lib-q-stark      -- `cargo publish -p lib-q-stark --dry-run`     exit 0 (2026-08-13)
+#
+# lib-q-hpke and lib-q-stark were the two crates card t_103554a6 recorded as UNVERIFIED against this
+# failure class: at the time their dry-runs died earlier, on dependencies not yet published at
+# 0.0.11, so the panic-runtime question could not be reached. Both were cleared once 0.0.11 was live.
+KNOWN_LINKABLE = {
+    "lib-q-blind-pcs",
+    "lib-q-hpke",
+    "lib-q-stark",
+}
+
+
+def default_reaches_std(features: dict[str, list[str]]) -> bool:
+    """Does the `default` feature set transitively enable this crate's own `std` feature?
+
+    Walks the crate's own feature graph only. A `dep/std` entry (e.g. `lib-q-core/std`) does NOT
+    count: it turns std on for a DEPENDENCY, which is not the same as this crate being built with
+    std, and it is precisely the distinction lib-q-kem got wrong. Cycle-safe via `seen`.
+    """
+    seen: set[str] = set()
+    stack = list(features.get("default", []))
+    while stack:
+        f = stack.pop()
+        if f in seen:
+            continue
+        seen.add(f)
+        if f == "std":
+            return True
+        if "/" in f:  # dependency feature, not one of ours
+            continue
+        stack.extend(features.get(f, []))
+    return False
+
+
+def is_publishable(pkg: dict) -> bool:
+    """`publish` is None when unrestricted, and a (possibly empty) list when restricted.
+
+    An empty list means `publish = false` -- never uploaded, so `cargo publish --verify` never
+    builds it and it cannot break a release. wasm-browser-demo is the one such cdylib here.
+    """
+    return pkg.get("publish") is None
+
+
+def is_cdylib(pkg: dict) -> bool:
+    return any("cdylib" in (t.get("crate_types") or []) for t in pkg.get("targets", []))
+
+
+def classify(packages: list[dict]) -> tuple[list[str], list[str], list[str]]:
+    """-> (flagged, allowlisted, safe): publishable cdylib crates split by default-feature shape.
+
+    `flagged`     - default does not reach std, NOT allowlisted -> --static fails on these.
+    `allowlisted` - same shape, but a recorded build says they link -> --build re-proves them.
+    `safe`        - default reaches std, so a panic runtime is present by construction.
+    """
+    flagged, allowlisted, safe = [], [], []
+    for pkg in packages:
+        if not is_cdylib(pkg) or not is_publishable(pkg):
+            continue
+        name = pkg["name"]
+        if default_reaches_std(pkg.get("features") or {}):
+            safe.append(name)
+        elif name in KNOWN_LINKABLE:
+            allowlisted.append(name)
+        else:
+            flagged.append(name)
+    return sorted(flagged), sorted(allowlisted), sorted(safe)
+
+
+def load_packages() -> list[dict]:
+    out = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+        cwd=ROOT, capture_output=True, text=True, check=True).stdout
+    return json.loads(out)["packages"]
+
+
+def build_bare_default(name: str) -> tuple[int, str]:
+    """Run the true predicate. Returns (exit code, last few lines of output)."""
+    r = subprocess.run(["cargo", "build", "-p", name, "--lib"],
+                       cwd=ROOT, capture_output=True, text=True)
+    tail = "\n".join((r.stderr or r.stdout).strip().splitlines()[-6:])
+    return r.returncode, tail
+
+
+# -------------------------------------------------------------------------------------------
+# self-test / mutation battery
+# -------------------------------------------------------------------------------------------
+
+def _pkg(name, *, cdylib=True, publish=None, features=None):
+    return {
+        "name": name,
+        "publish": publish,
+        "features": features if features is not None else {"default": []},
+        "targets": [{"crate_types": ["cdylib", "rlib"] if cdylib else ["rlib"]}],
+    }
+
+
+def self_test() -> int:
+    """Prove the classifier can say BOTH words before any real verdict is trusted.
+
+    A guard that has only ever been watched to pass is a claim, not a control -- every case below
+    asserts a specific WRONG answer would be caught, not merely that the code runs.
+    """
+    problems, cases = 0, 0
+
+    def check(label, cond):
+        nonlocal problems, cases
+        cases += 1
+        if not cond:
+            print(f"  MUTATION-CHECK FAIL ({label})")
+            problems = 1
+
+    # A: THE REAL INCIDENT SHAPE -- lib-q-kem as it was: cdylib, default = [] -> MUST flag.
+    f, a, s = classify([_pkg("lib-q-kem", features={"default": [], "std": []})])
+    check("A: cdylib with default=[] must be flagged", f == ["lib-q-kem"])
+
+    # B: the fix -- default = ["std"] -> must NOT flag.
+    f, a, s = classify([_pkg("lib-q-kem", features={"default": ["std"], "std": []})])
+    check("B: default=['std'] must be safe", s == ["lib-q-kem"] and not f)
+
+    # C: std reached TRANSITIVELY through another feature -> must NOT flag.
+    f, a, s = classify([_pkg("c", features={"default": ["full"], "full": ["alloc", "std"], "std": []})])
+    check("C: transitively-reached std must be safe", s == ["c"] and not f)
+
+    # D: a DEPENDENCY's std (`lib-q-core/std`) is NOT this crate's std -> MUST still flag. This is
+    # the exact confusion behind the incident; a classifier that accepts `dep/std` reports lib-q-kem
+    # green while it cannot link.
+    f, a, s = classify([_pkg("d", features={"default": ["lib-q-core/std"], "std": []})])
+    check("D: a dependency's std must not count as ours", f == ["d"])
+
+    # E: not a cdylib -> irrelevant, no panic-runtime requirement.
+    f, a, s = classify([_pkg("e", cdylib=False, features={"default": []})])
+    check("E: non-cdylib must be ignored", not f and not s and not a)
+
+    # F: publish = false -> never built by `cargo publish --verify`, cannot break a release.
+    f, a, s = classify([_pkg("wasm-browser-demo", publish=[], features={"default": []})])
+    check("F: publish=false cdylib must be ignored", not f and not a)
+
+    # G: allowlisted crate of the flagged shape -> allowlisted, not flagged (but --build re-proves).
+    f, a, s = classify([_pkg("lib-q-hpke", features={"default": ["alloc"], "std": []})])
+    check("G: allowlisted crate must not fail --static", a == ["lib-q-hpke"] and not f)
+
+    # H: a feature cycle must terminate rather than hang.
+    f, a, s = classify([_pkg("h", features={"default": ["x"], "x": ["y"], "y": ["x"]})])
+    check("H: feature cycle must terminate and stay flagged", f == ["h"])
+
+    # I: crate with NO `std` feature at all and default=[] -> flagged (cannot reach std).
+    f, a, s = classify([_pkg("i", features={"default": []})])
+    check("I: crate with no std feature must be flagged", f == ["i"])
+
+    if problems:
+        print("SELF-TEST FAILED -- the cdylib link guard is not classifying what it claims.")
+        return 1
+    print(f"ci-guard-cdylib-default-link: self-test OK ({cases} mutation cases passed)")
+    return 0
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if "--self-test" in argv:
+        return self_test()
+
+    # Re-prove detection before trusting a clean result on the real tree: a broken guard and a
+    # healthy workspace produce identical output otherwise.
+    if self_test() != 0:
+        return 1
+
+    do_build = "--build" in argv
+    flagged, allowlisted, safe = classify(load_packages())
+
+    print(f"ci-guard-cdylib-default-link: {len(flagged) + len(allowlisted) + len(safe)} publishable "
+          f"cdylib crate(s); {len(safe)} reach std by default, {len(allowlisted)} allowlisted, "
+          f"{len(flagged)} flagged")
+
+    if flagged:
+        print("\nFATAL: publishable cdylib crate(s) whose DEFAULT features do not enable `std`:")
+        for n in flagged:
+            print(f"  {n}")
+        print("\nA native cdylib needs a panic runtime. `cargo publish --verify` builds exactly this")
+        print("combination -- bare default features on the host -- and CI does not, which is how")
+        print("lib-q-kem reached a tag green and killed the v0.0.11 release at tier 3.")
+        print("\nFix by setting `default = [\"std\"]` (what lib-q-core, lib-q-intrinsics and lib-q-kem")
+        print("do). no_std consumers are unaffected: they depend with `default-features = false`.")
+        print("If the crate genuinely links with bare defaults, run")
+        print("`cargo build -p <crate> --lib`, confirm exit 0, and add it to KNOWN_LINKABLE with")
+        print("the date -- `--build` mode re-proves that claim on every release.")
+        return 1
+
+    if not do_build:
+        print("ci-guard-cdylib-default-link: OK (static shape check; run --build to link them)")
+        return 0
+
+    # --build: re-prove every allowlisted claim empirically.
+    print(f"\n--build: linking {len(allowlisted)} allowlisted crate(s) with bare default features")
+    failures = []
+    for n in allowlisted:
+        rc, tail = build_bare_default(n)
+        print(f"  {n:<24} cargo build --lib -> exit {rc}")
+        if rc != 0:
+            failures.append((n, tail))
+
+    if failures:
+        print("\nFATAL: an allowlisted crate no longer links with bare default features. Its entry in")
+        print("       KNOWN_LINKABLE is a stale claim, and `cargo publish --verify` will fail on it")
+        print("       mid-release -- after earlier crates are already immutable on crates.io:")
+        for n, tail in failures:
+            print(f"\n  {n}:\n{tail}")
+        return 1
+
+    print("ci-guard-cdylib-default-link: OK (every flagged-shape crate links with bare defaults)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
v0.0.11 published 35 crates and then died at tier 3. Two guards should have caught it; neither could.

## 1. `cargo publish --verify`'s build is a combination no CI job runs

It builds each crate with **bare default features, on the host**. CI builds `--all-features`,
`std,all-algorithms`, and `--no-default-features` cross-compiled to `thumbv7em-none-eabi`. None of
those is that combination, so a crate can be green everywhere and still fail to package:

```
error: unwinding panics are not supported without std
error: could not compile `lib-q-core` (lib)
```

`lib-q-kem` is `crate-type = ["cdylib", "rlib"]` — a native cdylib needs a panic runtime — while its
own `default` was `[]` and it pinned `lib-q-core = { default-features = false }`. `--all-features`
structurally *cannot* see this (it turns `std` on); the `thumbv7em` build is a different target with
no cdylib to link.

New `scripts/ci-guard-cdylib-default-link.sh`, two modes:

* static shape check on every PR (`ci.yml` / `core-validation`)
* real `cargo build -p <crate> --lib` on the release path (`cd.yml` / `pre-release-validation`)

The static shape is **necessary but not sufficient** — `lib-q-blind-pcs`, `lib-q-hpke` and
`lib-q-stark` have it and link fine, so they sit in a `KNOWN_LINKABLE` allowlist that `--build`
re-proves every release rather than exempting.

Proven red before trusting it green: reverting `lib-q-kem` to `default = []` (the tree that shipped
broken) gives guard exit 1 and `cargo build -p lib-q-kem --lib` exit 101; restored, both exit 0.
9/9 self-test cases pass.

## 2. `ci-guard-yanked-deps.sh --published` was vacuous since it was written

It audited the *workspace* version, and CD runs it on a tag where that version is by construction
not yet published — so every crate hit the "no such version" skip and **zero** were ever audited.
It now resolves each crate's latest live version, and a zero-crate audit FAILS rather than passing
silently. Against the live registry: **76 crates audited**, previously structurally 0.

## Also

* `scripts/bump-workspace-version.py` — promoted from a scratch one-off. 434 pins across 84
  manifests at 0.0.11; `--npm` also fixes `npm/**/package.json`, which drifts invisibly because CD
  overwrites it at publish time (`npm/lib-q-types` still said `0.0.2`). `--report-docs` lists and
  never rewrites: at 0.0.11 `lib-q-hqc/SECURITY.md` and `lib-q-types/src/hqc.rs` were *correct* to
  keep saying `lib-q-types <= 0.0.10`.
* `docs/crates-io-publish.md` — the failure class written up.

## Checked and deliberately left alone

`ci-guard-publish-order.sh` and `ci-guard-new-crates-and-npm.sh` are **not** vacuous — both go red
under mutation. The npm/wasm ordering gap does not exist: no npm package depends on another, and
both npm jobs sit transitively after all 43 Rust publish jobs. No guard added there — asserting a
constraint that does not exist is how the vacuous guard arose in the first place.

`lib-q-hpke` and `lib-q-stark`, unverified at release time, both dry-run clean now that 0.0.11 is
live (their dry-runs previously died earlier, on unpublished dependencies).
